### PR TITLE
Add deletepj command for removing Project

### DIFF
--- a/src/main/java/seedu/socket/commons/core/Messages.java
+++ b/src/main/java/seedu/socket/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX = "The project index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/socket/logic/commands/DeleteProjectCommand.java
+++ b/src/main/java/seedu/socket/logic/commands/DeleteProjectCommand.java
@@ -1,0 +1,58 @@
+package seedu.socket.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.socket.commons.core.Messages;
+import seedu.socket.commons.core.index.Index;
+import seedu.socket.logic.commands.exceptions.CommandException;
+import seedu.socket.model.Model;
+import seedu.socket.model.project.Project;
+
+/**
+ * Deletes a project identified using its displayed index from SOCket.
+ */
+public class DeleteProjectCommand extends Command {
+
+    public static final String COMMAND_WORD = "deletepj";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the project identified by the index number used in the displayed project list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_PROJECT_SUCCESS = "Deleted Project: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteProjectCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Project> lastShownList = model.getFilteredProjectList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+        }
+
+        Project projectToDelete = lastShownList.get(targetIndex.getZeroBased());
+        if (!model.getViewedProject().isEmpty()
+                && projectToDelete.isSameProject(model.getViewedProject().get(0))) {
+            model.updateViewedProject(null);
+        }
+        model.deleteProject(projectToDelete);
+        model.commitSocket();
+        return new CommandResult(String.format(MESSAGE_DELETE_PROJECT_SUCCESS, projectToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteProjectCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteProjectCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/socket/logic/parser/DeleteProjectCommandParser.java
+++ b/src/main/java/seedu/socket/logic/parser/DeleteProjectCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.socket.logic.parser;
+
+import static seedu.socket.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.socket.commons.core.index.Index;
+import seedu.socket.logic.commands.DeleteProjectCommand;
+import seedu.socket.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object
+ */
+public class DeleteProjectCommandParser implements Parser<DeleteProjectCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteProjectCommand
+     * and returns a DeleteProjectCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteProjectCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteProjectCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteProjectCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/socket/logic/parser/SocketParser.java
+++ b/src/main/java/seedu/socket/logic/parser/SocketParser.java
@@ -10,6 +10,7 @@ import seedu.socket.logic.commands.AddCommand;
 import seedu.socket.logic.commands.ClearCommand;
 import seedu.socket.logic.commands.Command;
 import seedu.socket.logic.commands.DeleteCommand;
+import seedu.socket.logic.commands.DeleteProjectCommand;
 import seedu.socket.logic.commands.EditCommand;
 import seedu.socket.logic.commands.ExitCommand;
 import seedu.socket.logic.commands.FindCommand;
@@ -78,6 +79,9 @@ public class SocketParser {
 
         case RemoveCommand.COMMAND_WORD:
             return new RemoveCommandParser().parse(arguments);
+
+        case DeleteProjectCommand.COMMAND_WORD:
+            return new DeleteProjectCommandParser().parse(arguments);
 
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();

--- a/src/main/java/seedu/socket/model/Model.java
+++ b/src/main/java/seedu/socket/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.socket.commons.core.GuiSettings;
 import seedu.socket.model.person.Person;
+import seedu.socket.model.project.Project;
 
 /**
  * The API of the Model component.
@@ -13,6 +14,9 @@ import seedu.socket.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Project> PREDICATE_SHOW_ALL_PROJECTS = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -99,6 +103,54 @@ public interface Model {
      * Sorts the list of people by given {@code category}
      */
     void sortPersonList(String category);
+
+    /**
+     * Returns true if a project with the same identity as {@code project} exists in the {@code Socket}.
+     */
+    boolean hasProject(Project project);
+
+    /**
+     * Deletes the given project.
+     * The project must exist in the {@code Socket}.
+     */
+    void deleteProject(Project target);
+
+    /**
+     * Adds the given project.
+     * {@code project} must not already exist in the {@code Socket}.
+     */
+    void addProject(Project project);
+
+    /**
+     * Replaces the given project {@code target} with {@code editedProject}.
+     * {@code target} must exist in the {@code Socket}.
+     * The project identity of {@code editedProject} must not be the same as another existing project in the
+     * {@code Socket}.
+     */
+    void setProject(Project target, Project editedProject);
+
+    /** Returns an unmodifiable view of the filtered project list */
+    ObservableList<Project> getFilteredProjectList();
+
+    /** Returns a project to be viewed */
+    ObservableList<Project> getViewedProject();
+
+    /**
+     * Updates the filter of the filtered project list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredProjectList(Predicate<Project> predicate);
+
+    /**
+     * Updates the project to be viewed in filtered person list by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateViewedProject(Project project);
+
+    /**
+     * Sorts the list of projects by given {@code category}
+     */
+    void sortProjectList(String category);
 
     /**
      * Saves the current {@code Socket} state.

--- a/src/main/java/seedu/socket/model/ModelManager.java
+++ b/src/main/java/seedu/socket/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.socket.commons.core.GuiSettings;
 import seedu.socket.commons.core.LogsCenter;
 import seedu.socket.model.person.Person;
+import seedu.socket.model.project.Project;
 
 /**
  * Represents the in-memory model of the {@code Socket} data.
@@ -23,8 +24,11 @@ public class ModelManager implements Model {
     private final VersionedSocket versionedSocket;
     private final UserPrefs userPrefs;
     private FilteredList<Person> filteredPersons;
+    private FilteredList<Project> filteredProjects;
 
     private FilteredList<Person> viewedPerson;
+    private FilteredList<Project> viewedProject;
+
 
     /**
      * Initializes a {@code ModelManager} with the given {@code ReadOnlySocket} socket
@@ -41,6 +45,9 @@ public class ModelManager implements Model {
         filteredPersons = new FilteredList<>(this.socket.getPersonList());
         viewedPerson = new FilteredList<>(this.socket.getPersonList());
         viewedPerson.setPredicate(x -> false);
+        filteredProjects = new FilteredList<>(this.socket.getProjectList());
+        viewedProject = new FilteredList<>(this.socket.getProjectList());
+        viewedProject.setPredicate(x -> false);
     }
 
     public ModelManager() {
@@ -119,6 +126,30 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasProject(Project project) {
+        requireNonNull(project);
+        return socket.hasProject(project);
+    }
+
+    @Override
+    public void deleteProject(Project target) {
+        socket.removeProject(target);
+    }
+
+    @Override
+    public void addProject(Project project) {
+        socket.addProject(project);
+        updateFilteredProjectList(PREDICATE_SHOW_ALL_PROJECTS);
+    }
+
+    @Override
+    public void setProject(Project target, Project editedProject) {
+        requireAllNonNull(target, editedProject);
+
+        socket.setProject(target, editedProject);
+    }
+
+    @Override
     public void commitSocket() {
         versionedSocket.commit(socket);
     }
@@ -176,6 +207,38 @@ public class ModelManager implements Model {
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
+    /**
+     * Returns an unmodifiable view of the list of {@code Project} backed by the internal list of
+     * {@code versionedSocket}
+     */
+    @Override
+    public ObservableList<Project> getFilteredProjectList() {
+        return filteredProjects;
+    }
+
+    @Override
+    public void updateFilteredProjectList(Predicate<Project> predicate) {
+        requireNonNull(predicate);
+        filteredProjects.setPredicate(predicate);
+    }
+
+    @Override
+    public ObservableList<Project> getViewedProject() {
+        return viewedProject;
+    }
+
+    @Override
+    public void updateViewedProject(Project project) {
+        viewedProject.setPredicate(x -> x.isSameProject(project));
+    }
+
+    @Override
+    public void sortProjectList(String category) {
+        // TODO modify to sort project
+        // socket.sort(category);
+        updateFilteredProjectList(PREDICATE_SHOW_ALL_PROJECTS);
+    }
+
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object
@@ -193,7 +256,9 @@ public class ModelManager implements Model {
         return socket.equals(other.socket)
                 && userPrefs.equals(other.userPrefs)
                 && filteredPersons.equals(other.filteredPersons)
-                && viewedPerson.equals(other.viewedPerson);
+                && viewedPerson.equals(other.viewedPerson)
+                && filteredProjects.equals(other.filteredProjects)
+                && viewedProject.equals(other.viewedProject);
     }
 
 }

--- a/src/main/java/seedu/socket/model/person/predicate/FindCommandProjectNamePredicate.java
+++ b/src/main/java/seedu/socket/model/person/predicate/FindCommandProjectNamePredicate.java
@@ -1,0 +1,33 @@
+package seedu.socket.model.person.predicate;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.socket.commons.util.StringUtil;
+import seedu.socket.model.person.Person;
+import seedu.socket.model.project.Project;
+
+/**
+ * Tests that a {@code Project}'s {@code ProjectName} matches any of the keywords given.
+ */
+public class FindCommandProjectNamePredicate implements Predicate<Project> {
+    private final List<String> keywords;
+
+    public FindCommandProjectNamePredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Project project) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(project.getName().projectName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindCommandProjectNamePredicate // instanceof handles nulls
+                && keywords.equals(((FindCommandProjectNamePredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/socket/model/person/predicate/FindCommandProjectNamePredicate.java
+++ b/src/main/java/seedu/socket/model/person/predicate/FindCommandProjectNamePredicate.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.socket.commons.util.StringUtil;
-import seedu.socket.model.person.Person;
 import seedu.socket.model.project.Project;
 
 /**

--- a/src/test/java/seedu/socket/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/AddCommandTest.java
@@ -21,6 +21,7 @@ import seedu.socket.model.ReadOnlySocket;
 import seedu.socket.model.ReadOnlyUserPrefs;
 import seedu.socket.model.Socket;
 import seedu.socket.model.person.Person;
+import seedu.socket.model.project.Project;
 import seedu.socket.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -108,6 +109,17 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+
+        @Override
+        public ObservableList<Project> getViewedProject() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateViewedProject(Project project) {
+            throw new AssertionError("This method should not be called.");
+        }
+
         @Override
         public Path getSocketFilePath() {
             throw new AssertionError("This method should not be called.");
@@ -160,6 +172,41 @@ public class AddCommandTest {
 
         @Override
         public void sortPersonList(String category) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addProject(Project project) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasProject(Project project) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteProject(Project target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setProject(Project target, Project editedProject) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Project> getFilteredProjectList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredProjectList(Predicate<Project> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortProjectList(String category) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/socket/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/socket/logic/commands/CommandTestUtil.java
@@ -21,6 +21,8 @@ import seedu.socket.model.Model;
 import seedu.socket.model.Socket;
 import seedu.socket.model.person.Person;
 import seedu.socket.model.person.predicate.FindCommandNamePredicate;
+import seedu.socket.model.person.predicate.FindCommandProjectNamePredicate;
+import seedu.socket.model.project.Project;
 import seedu.socket.testutil.EditPersonDescriptorBuilder;
 import seedu.socket.testutil.RemovePersonDescriptorBuilder;
 import seedu.socket.testutil.TypicalPersons;
@@ -147,6 +149,7 @@ public class CommandTestUtil {
         assertEquals(expectedSocket, actualModel.getSocket());
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
     }
+
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s {@code Socket}.
@@ -159,6 +162,20 @@ public class CommandTestUtil {
         model.updateFilteredPersonList(new FindCommandNamePredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredPersonList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the project at the given {@code targetIndex} in the
+     * {@code model}'s {@code Socket}.
+     */
+    public static void showProjectAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredProjectList().size());
+
+        Project project = model.getFilteredProjectList().get(targetIndex.getZeroBased());
+        final String[] splitName = project.getName().projectName.split("\\s+");
+        model.updateFilteredProjectList(new FindCommandProjectNamePredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredProjectList().size());
     }
 
     /**

--- a/src/test/java/seedu/socket/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/DeleteCommandTest.java
@@ -68,7 +68,7 @@ public class DeleteCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Index outOfBoundIndex = INDEX_SECOND_PERSON;
-        // ensures that outOfBoundIndex is still in bounds of address book list
+        // ensures that outOfBoundIndex is still in bounds of socket list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getSocket().getPersonList().size());
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);

--- a/src/test/java/seedu/socket/logic/commands/DeleteProjectCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/DeleteProjectCommandTest.java
@@ -1,0 +1,113 @@
+package seedu.socket.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.socket.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.socket.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.socket.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.socket.logic.commands.CommandTestUtil.showProjectAtIndex;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_SECOND_PROJECT;
+import static seedu.socket.testutil.TypicalProjects.getTypicalSocket;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.socket.commons.core.Messages;
+import seedu.socket.commons.core.index.Index;
+import seedu.socket.model.Model;
+import seedu.socket.model.ModelManager;
+import seedu.socket.model.UserPrefs;
+import seedu.socket.model.person.Person;
+import seedu.socket.model.project.Project;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteProjectCommand}.
+ */
+public class DeleteProjectCommandTest {
+
+    private Model model = new ModelManager(getTypicalSocket(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Project projectToDelete = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+        DeleteProjectCommand deleteProjectCommand = new DeleteProjectCommand(INDEX_FIRST_PROJECT);
+
+        String expectedMessage = String.format(DeleteProjectCommand.MESSAGE_DELETE_PROJECT_SUCCESS, projectToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getSocket(), new UserPrefs());
+        expectedModel.deleteProject(projectToDelete);
+
+        assertCommandSuccess(deleteProjectCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredProjectList().size() + 1);
+        DeleteProjectCommand deleteProjectCommand = new DeleteProjectCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteProjectCommand, model, Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showProjectAtIndex(model, INDEX_FIRST_PROJECT);
+
+        Project projectToDelete = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+        DeleteProjectCommand deleteProjectCommand = new DeleteProjectCommand(INDEX_FIRST_PROJECT);
+
+        String expectedMessage = String.format(DeleteProjectCommand.MESSAGE_DELETE_PROJECT_SUCCESS, projectToDelete);
+
+        Model expectedModel = new ModelManager(model.getSocket(), new UserPrefs());
+        expectedModel.deleteProject(projectToDelete);
+        showNoProject(expectedModel);
+
+        assertCommandSuccess(deleteProjectCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showProjectAtIndex(model, INDEX_FIRST_PROJECT);
+
+        Index outOfBoundIndex = INDEX_SECOND_PROJECT;
+        // ensures that outOfBoundIndex is still in bounds of socket list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getSocket().getProjectList().size());
+
+        DeleteProjectCommand deleteProjectCommand = new DeleteProjectCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteProjectCommand, model, Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteProjectCommand deleteProjectFirstCommand = new DeleteProjectCommand(INDEX_FIRST_PROJECT);
+        DeleteProjectCommand deleteProjectSecondCommand = new DeleteProjectCommand(INDEX_SECOND_PROJECT);
+
+        // same object -> returns true
+        assertTrue(deleteProjectFirstCommand.equals(deleteProjectFirstCommand));
+
+        // same values -> returns true
+        DeleteProjectCommand deleteProjectFirstCommandCopy = new DeleteProjectCommand(INDEX_FIRST_PROJECT);
+        assertTrue(deleteProjectFirstCommand.equals(deleteProjectFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteProjectFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteProjectSecondCommand.equals(null));
+
+        // different project -> returns false
+        assertFalse(deleteProjectFirstCommand.equals(deleteProjectSecondCommand));
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoProject(Model model) {
+        model.updateFilteredProjectList(p -> false);
+
+        assertTrue(model.getFilteredProjectList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/socket/logic/commands/DeleteProjectCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/DeleteProjectCommandTest.java
@@ -4,11 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.socket.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.socket.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.socket.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.socket.logic.commands.CommandTestUtil.showProjectAtIndex;
-import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
-import static seedu.socket.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.socket.testutil.TypicalIndexes.INDEX_SECOND_PROJECT;
 import static seedu.socket.testutil.TypicalProjects.getTypicalSocket;
 
@@ -19,7 +16,6 @@ import seedu.socket.commons.core.index.Index;
 import seedu.socket.model.Model;
 import seedu.socket.model.ModelManager;
 import seedu.socket.model.UserPrefs;
-import seedu.socket.model.person.Person;
 import seedu.socket.model.project.Project;
 
 /**

--- a/src/test/java/seedu/socket/logic/parser/DeleteProjectCommandParserTest.java
+++ b/src/test/java/seedu/socket/logic/parser/DeleteProjectCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.socket.logic.parser;
+
+import static seedu.socket.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.socket.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.socket.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.socket.logic.commands.DeleteProjectCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the DeleteProjectCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteProjectCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class DeleteProjectCommandParserTest {
+
+    private DeleteProjectCommandParser parser = new DeleteProjectCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteProjectCommand() {
+        assertParseSuccess(parser, "1", new DeleteProjectCommand(INDEX_FIRST_PROJECT));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteProjectCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/socket/logic/parser/SocketParserTest.java
+++ b/src/test/java/seedu/socket/logic/parser/SocketParserTest.java
@@ -19,6 +19,7 @@ import static seedu.socket.logic.parser.CliSyntax.PREFIX_PROFILE;
 import static seedu.socket.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.socket.testutil.Assert.assertThrows;
 import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import seedu.socket.logic.commands.AddCommand;
 import seedu.socket.logic.commands.ClearCommand;
 import seedu.socket.logic.commands.DeleteCommand;
+import seedu.socket.logic.commands.DeleteProjectCommand;
 import seedu.socket.logic.commands.EditCommand;
 import seedu.socket.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.socket.logic.commands.ExitCommand;
@@ -72,6 +74,13 @@ public class SocketParserTest {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_deletepj() throws Exception {
+        DeleteProjectCommand command = (DeleteProjectCommand) parser.parseCommand(
+                DeleteProjectCommand.COMMAND_WORD + " " + INDEX_FIRST_PROJECT.getOneBased());
+        assertEquals(new DeleteProjectCommand(INDEX_FIRST_PROJECT), command);
     }
 
     @Test

--- a/src/test/java/seedu/socket/model/ModelManagerTest.java
+++ b/src/test/java/seedu/socket/model/ModelManagerTest.java
@@ -4,9 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.socket.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.socket.model.Model.PREDICATE_SHOW_ALL_PROJECTS;
 import static seedu.socket.testutil.Assert.assertThrows;
 import static seedu.socket.testutil.TypicalPersons.ALICE;
 import static seedu.socket.testutil.TypicalPersons.BENSON;
+import static seedu.socket.testutil.TypicalProjects.ALPHA;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.socket.commons.core.GuiSettings;
 import seedu.socket.model.person.predicate.FindCommandNamePredicate;
+import seedu.socket.model.person.predicate.FindCommandProjectNamePredicate;
 import seedu.socket.testutil.SocketBuilder;
 
 public class ModelManagerTest {
@@ -78,8 +81,18 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasProject_nullProject_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasProject(null));
+    }
+
+    @Test
     public void hasPerson_personNotInSocket_returnsFalse() {
         assertFalse(modelManager.hasPerson(ALICE));
+    }
+
+    @Test
+    public void hasProject_projectNotInSocket_returnsFalse() {
+        assertFalse(modelManager.hasProject(ALPHA));
     }
 
     @Test
@@ -89,13 +102,24 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasProject_projectInSocket_returnsTrue() {
+        modelManager.addProject(ALPHA);
+        assertTrue(modelManager.hasProject(ALPHA));
+    }
+
+    @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
     }
 
     @Test
+    public void getFilteredProjectList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredProjectList().remove(0));
+    }
+
+    @Test
     public void equals() {
-        Socket socket = new SocketBuilder().withPerson(ALICE).withPerson(BENSON).build();
+        Socket socket = new SocketBuilder().withPerson(ALICE).withPerson(BENSON).withProject(ALPHA).build();
         Socket differentSocket = new Socket();
         UserPrefs userPrefs = new UserPrefs();
 
@@ -120,14 +144,23 @@ public class ModelManagerTest {
         String[] keywords = ALICE.getName().fullName.split("\\s+");
         modelManager.updateFilteredPersonList(new FindCommandNamePredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(socket, userPrefs)));
+        keywords = ALPHA.getName().projectName.split("\\s+");
+        modelManager.updateFilteredProjectList(new FindCommandProjectNamePredicate(Arrays.asList(keywords)));
+        assertFalse(modelManager.equals(new ModelManager(socket, userPrefs)));
 
-        //different viewedPerson -> returns false
+        // different viewedPerson -> returns false
         modelManager = new ModelManager(socket, userPrefs);
         modelManager.updateViewedPerson(ALICE);
         assertFalse(modelManager.equals(new ModelManager(socket, userPrefs)));
 
+        // different viewedProject -> returns false
+        modelManager = new ModelManager(socket, userPrefs);
+        modelManager.updateViewedProject(ALPHA);
+        assertFalse(modelManager.equals(new ModelManager(socket, userPrefs)));
+
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        modelManager.updateFilteredProjectList(PREDICATE_SHOW_ALL_PROJECTS);
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();

--- a/src/test/java/seedu/socket/testutil/SocketBuilder.java
+++ b/src/test/java/seedu/socket/testutil/SocketBuilder.java
@@ -2,6 +2,7 @@ package seedu.socket.testutil;
 
 import seedu.socket.model.Socket;
 import seedu.socket.model.person.Person;
+import seedu.socket.model.project.Project;
 
 /**
  * A utility class to help with building {@code Socket} objects.
@@ -25,6 +26,14 @@ public class SocketBuilder {
      */
     public SocketBuilder withPerson(Person person) {
         socket.addPerson(person);
+        return this;
+    }
+
+    /**
+     * Adds a new {@code Project} to the {@code Socket} that we are building.
+     */
+    public SocketBuilder withProject(Project project) {
+        socket.addProject(project);
         return this;
     }
 

--- a/src/test/java/seedu/socket/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/socket/testutil/TypicalIndexes.java
@@ -9,4 +9,7 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST_PROJECT = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_PROJECT = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_PROJECT = Index.fromOneBased(3);
 }


### PR DESCRIPTION
`Messages.java`:
* add `MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX`

`DeleteProjectCommand.java`:
* create new command to delete projects

`DeleteProjectCommandParser.java`:
* create new parser to parse for `deletepj` command

`SocketParser.java`:
* update to handle `DeleteProjectCommand.COMMAND_WORD`

`Model.java`:
* update with additional methods for handling `Project` operations

`ModelManager.java`:
* update to implement newly added methods

`FindCommandProjectNamePredicate.java`:
* add to match names
* used for testing purposes

`AddCommandTest.java`:
* update stub with new methods

`CommandTestUtil.java`:
* update methods to assist with tests on `Project` operations

`DeleteCommandTest.java`:
* modify comment

`DeleteProjectCommandTest.java`:
* add to test behavior of `deletepj` command

`DeleteProjectCommandParserTest.java`:
* add to test behavior of DeleteProjectCommandParser.java

`SocketParserTest.java`:
* update to test for new `deletepj` command

`ModelManagerTest.java`:
* update for new methods

`SocketBuilder.java`:
* update to allow addition of `Project`

`TypicalIndexes.java`:
* update with constants for `Project` indices