### PR TITLE
Fix lack of updates to `Person` references

### DIFF
--- a/src/main/java/seedu/socket/model/Socket.java
+++ b/src/main/java/seedu/socket/model/Socket.java
@@ -2,10 +2,7 @@ package seedu.socket.model;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -108,6 +105,8 @@ public class Socket implements ReadOnlySocket {
         requireNonNull(editedPerson);
 
         persons.setPerson(target, editedPerson);
+        // update references
+        projects.updateMemberInProjects(target, editedPerson);
     }
 
     /**
@@ -116,22 +115,8 @@ public class Socket implements ReadOnlySocket {
      */
     public void removePerson(Person key) {
         persons.remove(key);
-        // remove key references
-        ArrayList<Project> projectsToEdit = new ArrayList<>(); // store projects to edit to avoid concurrent update
-        for (Project project : projects) {
-            if (project.getMembers().contains(key)) {
-                projectsToEdit.add(project);
-            }
-        }
-        while (!projectsToEdit.isEmpty()) { // update matching projects in projects
-            Project projectToUpdate = projectsToEdit.remove(0);
-            Set<Person> updatedMembers = new HashSet<>(projectToUpdate.getMembers());
-            updatedMembers.remove(key);
-            Project updatedProject = new Project(projectToUpdate.getName(), projectToUpdate.getRepoHost(),
-                    projectToUpdate.getRepoName(), projectToUpdate.getDeadline(),
-                    projectToUpdate.getMeeting(), updatedMembers);
-            setProject(projectToUpdate, updatedProject);
-        }
+        // remove references
+        projects.removeMemberInProjects(key);
     }
 
     /**

--- a/src/main/java/seedu/socket/model/project/Project.java
+++ b/src/main/java/seedu/socket/model/project/Project.java
@@ -69,7 +69,10 @@ public class Project {
     public ProjectDeadline getDeadline() {
         return deadline;
     }
-    public ProjectMeeting getMeeting() { return meeting; }
+
+    public ProjectMeeting getMeeting() {
+        return meeting;
+    }
 
     /**
      * Returns an immutable {@code Person} set, which throws {@code UnsupportedOperationException}

--- a/src/main/java/seedu/socket/model/project/UniqueProjectList.java
+++ b/src/main/java/seedu/socket/model/project/UniqueProjectList.java
@@ -8,12 +8,16 @@ import static seedu.socket.model.project.Project.PROJ_NAME;
 import static seedu.socket.model.project.Project.PROJ_REPO_HOST;
 import static seedu.socket.model.project.Project.PROJ_REPO_NAME;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.socket.model.person.Person;
 import seedu.socket.model.project.exceptions.DuplicateProjectException;
 import seedu.socket.model.project.exceptions.ProjectNotFoundException;
 
@@ -100,6 +104,50 @@ public class UniqueProjectList implements Iterable<Project> {
         }
 
         internalList.setAll(projects);
+    }
+
+    /**
+     * Updates matching {@code Person} instances in the {@code members} of each exiting {@code Project} with the given
+     * {@code Person}.
+     */
+    public void updateMemberInProjects(Person person, Person editedPerson) {
+        ArrayList<Project> projectsToEdit = new ArrayList<>(); // store projects to edit to avoid concurrent update
+        for (Project project : internalList) {
+            if (project.getMembers().contains(person)) {
+                projectsToEdit.add(project);
+            }
+        }
+        while (!projectsToEdit.isEmpty()) { // update matching projects in projects
+            Project projectToUpdate = projectsToEdit.remove(0);
+            Set<Person> updatedMembers = new HashSet<>(projectToUpdate.getMembers());
+            updatedMembers.remove(person);
+            updatedMembers.add(editedPerson);
+            Project updatedProject = new Project(projectToUpdate.getName(), projectToUpdate.getRepoHost(),
+                    projectToUpdate.getRepoName(), projectToUpdate.getDeadline(),
+                    projectToUpdate.getMeeting(), updatedMembers);
+            setProject(projectToUpdate, updatedProject);
+        }
+    }
+
+    /**
+     * Removes the given {@code Person} instance from the {@code members} of each existing {@code Project}.
+     */
+    public void removeMemberInProjects(Person key) {
+        ArrayList<Project> projectsToEdit = new ArrayList<>(); // store projects to edit to avoid concurrent update
+        for (Project project : internalList) {
+            if (project.getMembers().contains(key)) {
+                projectsToEdit.add(project);
+            }
+        }
+        while (!projectsToEdit.isEmpty()) { // update matching projects in projects
+            Project projectToUpdate = projectsToEdit.remove(0);
+            Set<Person> updatedMembers = new HashSet<>(projectToUpdate.getMembers());
+            updatedMembers.remove(key);
+            Project updatedProject = new Project(projectToUpdate.getName(), projectToUpdate.getRepoHost(),
+                    projectToUpdate.getRepoName(), projectToUpdate.getDeadline(),
+                    projectToUpdate.getMeeting(), updatedMembers);
+            setProject(projectToUpdate, updatedProject);
+        }
     }
 
     /**

--- a/src/test/java/seedu/socket/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/EditCommandTest.java
@@ -28,6 +28,7 @@ import seedu.socket.model.UserPrefs;
 import seedu.socket.model.person.Person;
 import seedu.socket.testutil.EditPersonDescriptorBuilder;
 import seedu.socket.testutil.PersonBuilder;
+import seedu.socket.testutil.TypicalProjects;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
@@ -35,6 +36,7 @@ import seedu.socket.testutil.PersonBuilder;
 public class EditCommandTest {
 
     private Model model = new ModelManager(getTypicalSocket(), new UserPrefs());
+    private Model modelWithProjects = new ModelManager(TypicalProjects.getTypicalSocket(), new UserPrefs());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
@@ -48,6 +50,20 @@ public class EditCommandTest {
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredListPersonInProject_success() {
+        Person editedPerson = new PersonBuilder().build();
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new Socket(modelWithProjects.getSocket()), new UserPrefs());
+        expectedModel.setPerson(modelWithProjects.getFilteredPersonList().get(0), editedPerson);
+
+        assertCommandSuccess(editCommand, modelWithProjects, expectedMessage, expectedModel);
     }
 
     @Test
@@ -70,6 +86,29 @@ public class EditCommandTest {
         expectedModel.setPerson(lastPerson, editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredListPersonInProject_success() {
+        Person firstPerson = modelWithProjects.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(firstPerson);
+        Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withLanguages(VALID_LANGUAGE_CPLUSPLUS).withTags(VALID_TAG_HUSBAND).build();
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
+                .withPhone(VALID_PHONE_BOB).withLanguages(VALID_LANGUAGE_CPLUSPLUS)
+                .withTags(VALID_TAG_HUSBAND).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new Socket(modelWithProjects.getSocket()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        System.out.println(expectedModel.getFilteredProjectList());
+
+        assertCommandSuccess(editCommand, modelWithProjects, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/socket/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/EditCommandTest.java
@@ -106,8 +106,6 @@ public class EditCommandTest {
         Model expectedModel = new ModelManager(new Socket(modelWithProjects.getSocket()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
 
-        System.out.println(expectedModel.getFilteredProjectList());
-
         assertCommandSuccess(editCommand, modelWithProjects, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/socket/logic/commands/RemoveCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/RemoveCommandTest.java
@@ -24,6 +24,7 @@ import seedu.socket.model.UserPrefs;
 import seedu.socket.model.person.Person;
 import seedu.socket.testutil.PersonBuilder;
 import seedu.socket.testutil.RemovePersonDescriptorBuilder;
+import seedu.socket.testutil.TypicalProjects;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for RemoveCommand.
@@ -31,6 +32,7 @@ import seedu.socket.testutil.RemovePersonDescriptorBuilder;
 public class RemoveCommandTest {
 
     private Model model = new ModelManager(getTypicalSocket(), new UserPrefs());
+    private Model modelWithProjects = new ModelManager(TypicalProjects.getTypicalSocket(), new UserPrefs());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
@@ -56,6 +58,29 @@ public class RemoveCommandTest {
     }
 
     @Test
+    public void execute_allFieldsSpecifiedUnfilteredListPersonInProject_success() {
+        Person firstPerson = modelWithProjects.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder();
+        Person removedFieldPerson = personInList.withName("Alice Pauline").build();
+
+        RemovePersonDescriptor descriptor = new RemovePersonDescriptorBuilder()
+                .withProfile("alice-pauline")
+                .withAddress("123, Jurong West Ave 6, #08-111")
+                .withEmail("alice@example.com")
+                .withPhone("94351253")
+                .withTags("friends").build();
+        RemoveCommand removeCommand = new RemoveCommand(INDEX_FIRST_PERSON, descriptor);
+
+        String expectedMessage = String.format(RemoveCommand.MESSAGE_REMOVE_FIELD_SUCCESS, removedFieldPerson);
+
+        Model expectedModel = new ModelManager(new Socket(modelWithProjects.getSocket()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, removedFieldPerson);
+
+        assertCommandSuccess(removeCommand, modelWithProjects, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
         Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
         Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
@@ -75,6 +100,29 @@ public class RemoveCommandTest {
         expectedModel.setPerson(lastPerson, removedFieldPerson);
 
         assertCommandSuccess(removeCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredListPersonInProject_success() {
+        Person firstPerson = modelWithProjects.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder();
+        Person removedFieldPerson = personInList.withName("Alice Pauline")
+                .withAddress("123, Jurong West Ave 6, #08-111")
+                .withEmail("alice@example.com").build();
+
+        RemovePersonDescriptor descriptor = new RemovePersonDescriptorBuilder()
+                .withProfile("alice-pauline")
+                .withPhone("94351253")
+                .withTags("friends").build();
+        RemoveCommand removeCommand = new RemoveCommand(INDEX_FIRST_PERSON, descriptor);
+
+        String expectedMessage = String.format(RemoveCommand.MESSAGE_REMOVE_FIELD_SUCCESS, removedFieldPerson);
+
+        Model expectedModel = new ModelManager(new Socket(modelWithProjects.getSocket()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, removedFieldPerson);
+
+        assertCommandSuccess(removeCommand, modelWithProjects, expectedMessage, expectedModel);
     }
 
     @Test


### PR DESCRIPTION
Fix #151 

`Socket.java`:
* extract update functionality to `UniqueProjectList.java`

`UniqueProjectList.java`:
* add `updateMemberInProjects()` method to handle updates to `Person` instances in `edit`, `remove` commands
* add extracted functionality under `removeMemberInProjects()` method to handle removal of `Person` instances in `delete` commands

`EditCommandTest.java`:
* add tests with `TypicalProjects` data

`RemoveCommandTest.java`:
* add tests with `TypicalProjects` data