### PR TITLE
Add command clearpj

### DIFF
--- a/src/main/java/seedu/socket/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/socket/logic/commands/ClearCommand.java
@@ -19,7 +19,7 @@ public class ClearCommand extends Command {
             + "contain any of the keyword(s) (case-insensitive) in the tag fields.\n"
             + "Parameters: "
             + "[" + PREFIX_TAG + "TAG]\n"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_TAG + "friend OR " + COMMAND_WORD;;
+            + "Example: " + COMMAND_WORD + " " + PREFIX_TAG + "friend OR " + COMMAND_WORD;
 
     public static final String MESSAGE_SUCCESS = "SOCket has been cleared!";
 

--- a/src/main/java/seedu/socket/logic/commands/ClearProjectCommand.java
+++ b/src/main/java/seedu/socket/logic/commands/ClearProjectCommand.java
@@ -1,0 +1,25 @@
+package seedu.socket.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+
+import seedu.socket.model.Model;
+
+/**
+ * Clears the project list.
+ */
+public class ClearProjectCommand extends Command {
+    public static final String COMMAND_WORD = "clearpj";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Clears all project.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_SUCCESS = "Project list has been cleared!";
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.setProjects(new ArrayList<>());
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/socket/logic/parser/SocketParser.java
+++ b/src/main/java/seedu/socket/logic/parser/SocketParser.java
@@ -6,21 +6,7 @@ import static seedu.socket.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.socket.logic.commands.AddCommand;
-import seedu.socket.logic.commands.ClearCommand;
-import seedu.socket.logic.commands.Command;
-import seedu.socket.logic.commands.DeleteCommand;
-import seedu.socket.logic.commands.DeleteProjectCommand;
-import seedu.socket.logic.commands.EditCommand;
-import seedu.socket.logic.commands.ExitCommand;
-import seedu.socket.logic.commands.FindCommand;
-import seedu.socket.logic.commands.HelpCommand;
-import seedu.socket.logic.commands.ListCommand;
-import seedu.socket.logic.commands.RedoCommand;
-import seedu.socket.logic.commands.RemoveCommand;
-import seedu.socket.logic.commands.SortCommand;
-import seedu.socket.logic.commands.UndoCommand;
-import seedu.socket.logic.commands.ViewCommand;
+import seedu.socket.logic.commands.*;
 import seedu.socket.logic.parser.exceptions.ParseException;
 
 /**
@@ -91,6 +77,9 @@ public class SocketParser {
 
         case ViewCommand.COMMAND_WORD:
             return new ViewCommandParser().parse(arguments);
+
+        case ClearProjectCommand.COMMAND_WORD:
+            return new ClearProjectCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/socket/logic/parser/SocketParser.java
+++ b/src/main/java/seedu/socket/logic/parser/SocketParser.java
@@ -6,7 +6,22 @@ import static seedu.socket.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.socket.logic.commands.*;
+import seedu.socket.logic.commands.AddCommand;
+import seedu.socket.logic.commands.ClearCommand;
+import seedu.socket.logic.commands.ClearProjectCommand;
+import seedu.socket.logic.commands.Command;
+import seedu.socket.logic.commands.DeleteCommand;
+import seedu.socket.logic.commands.DeleteProjectCommand;
+import seedu.socket.logic.commands.EditCommand;
+import seedu.socket.logic.commands.ExitCommand;
+import seedu.socket.logic.commands.FindCommand;
+import seedu.socket.logic.commands.HelpCommand;
+import seedu.socket.logic.commands.ListCommand;
+import seedu.socket.logic.commands.RedoCommand;
+import seedu.socket.logic.commands.RemoveCommand;
+import seedu.socket.logic.commands.SortCommand;
+import seedu.socket.logic.commands.UndoCommand;
+import seedu.socket.logic.commands.ViewCommand;
 import seedu.socket.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/socket/model/Model.java
+++ b/src/main/java/seedu/socket/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.socket.model;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -134,6 +135,12 @@ public interface Model {
      * {@code Socket}.
      */
     void setProject(Project target, Project editedProject);
+
+    /**
+     * Replaces the contents of the project list with {@code projects}.
+     * {@code projects} must not contain duplicate projects.
+     */
+    void setProjects(List<Project> projects);
 
     /** Returns an unmodifiable view of the filtered project list */
     ObservableList<Project> getFilteredProjectList();

--- a/src/main/java/seedu/socket/model/ModelManager.java
+++ b/src/main/java/seedu/socket/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.socket.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -153,6 +154,11 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedProject);
 
         socket.setProject(target, editedProject);
+    }
+
+    @Override
+    public void setProjects(List<Project> projects) {
+        socket.setProjects(projects);
     }
 
     @Override

--- a/src/main/java/seedu/socket/model/project/Project.java
+++ b/src/main/java/seedu/socket/model/project/Project.java
@@ -69,7 +69,9 @@ public class Project {
     public ProjectDeadline getDeadline() {
         return deadline;
     }
-    public ProjectMeeting getMeeting() { return meeting; }
+    public ProjectMeeting getMeeting() {
+        return meeting;
+    }
 
     /**
      * Returns an immutable {@code Person} set, which throws {@code UnsupportedOperationException}

--- a/src/test/java/seedu/socket/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/AddCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.socket.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -197,6 +198,11 @@ public class AddCommandTest {
 
         @Override
         public void setProject(Project target, Project editedProject) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setProjects(List<Project> projects) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/socket/logic/commands/ClearProjectCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/ClearProjectCommandTest.java
@@ -1,0 +1,32 @@
+package seedu.socket.logic.commands;
+
+import static seedu.socket.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.socket.testutil.TypicalProjects.getTypicalSocket;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.socket.model.Model;
+import seedu.socket.model.ModelManager;
+import seedu.socket.model.UserPrefs;
+
+public class ClearProjectCommandTest {
+
+    @Test
+    public void execute_emptyProjectList_success() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+
+        assertCommandSuccess(new ClearProjectCommand(), model, ClearProjectCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_nonEmptyProjectList_success() {
+        Model model = new ModelManager(getTypicalSocket(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalSocket(), new UserPrefs());
+        expectedModel.setProjects(new ArrayList<>());
+
+        assertCommandSuccess(new ClearProjectCommand(), model, ClearProjectCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/seedu/socket/logic/parser/SocketParserTest.java
+++ b/src/test/java/seedu/socket/logic/parser/SocketParserTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.socket.logic.commands.AddCommand;
 import seedu.socket.logic.commands.ClearCommand;
+import seedu.socket.logic.commands.ClearProjectCommand;
 import seedu.socket.logic.commands.DeleteCommand;
 import seedu.socket.logic.commands.DeleteProjectCommand;
 import seedu.socket.logic.commands.EditCommand;
@@ -68,6 +69,11 @@ public class SocketParserTest {
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + TAG_DESC_FRIEND) instanceof ClearCommand);
+    }
+
+    @Test
+    public void parseCommand_clearpj() throws Exception {
+        assertTrue(parser.parseCommand(ClearProjectCommand.COMMAND_WORD) instanceof ClearProjectCommand);
     }
 
     @Test


### PR DESCRIPTION
What's change
- Add clear project command that reset the project list.

Model/ModelManager.java
- Add setProjects() that replaces the current project list.

ClearProjectCommand.java
- Make use of setProjects() in model in which empty arraylist can be replaced the existing project list.

SocketParser.java
- Add ClearProjectCommand into the cases.

Add tests of clear project command