### PR TITLE
Add removepj 

### DIFF
--- a/src/main/java/seedu/socket/logic/commands/EditProjectCommand.java
+++ b/src/main/java/seedu/socket/logic/commands/EditProjectCommand.java
@@ -49,7 +49,7 @@ public class EditProjectCommand extends Command {
 
     public static final String MESSAGE_EDIT_PROJECT_SUCCESS = "Edited Project: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PROJECT = "This person already exists in SOCket.";
+    public static final String MESSAGE_DUPLICATE_PROJECT = "This project already exists in SOCket.";
 
     private final Index index;
     private final EditProjectDescriptor editProjectDescriptor;
@@ -138,7 +138,6 @@ public class EditProjectCommand extends Command {
 
         /**
          * Copy constructor.
-         * A defensive copy of {@code languages} and {@code tags} is used internally.
          */
         public EditProjectDescriptor(EditProjectDescriptor toCopy) {
             setName(toCopy.name);

--- a/src/main/java/seedu/socket/logic/commands/RemoveProjectCommand.java
+++ b/src/main/java/seedu/socket/logic/commands/RemoveProjectCommand.java
@@ -2,8 +2,6 @@ package seedu.socket.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.socket.logic.parser.CliSyntax.PREFIX_DEADLINE;
-import static seedu.socket.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.socket.logic.parser.CliSyntax.PREFIX_LANGUAGE;
 import static seedu.socket.logic.parser.CliSyntax.PREFIX_MEETING;
 import static seedu.socket.logic.parser.CliSyntax.PREFIX_REPO_HOST;
 import static seedu.socket.logic.parser.CliSyntax.PREFIX_REPO_NAME;
@@ -41,8 +39,8 @@ public class RemoveProjectCommand extends Command {
             + "[" + PREFIX_DEADLINE + "[DEADLINE]] "
             + "[" + PREFIX_MEETING + "[MEETING]]\n "
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_LANGUAGE + " "
-            + PREFIX_EMAIL + "johndoe@example.com";
+            + PREFIX_DEADLINE + " "
+            + PREFIX_MEETING + "01/01/2023-2359";
 
     public static final String MESSAGE_REMOVE_FIELD_SUCCESS = "Remove field: %1$s";
 
@@ -60,7 +58,6 @@ public class RemoveProjectCommand extends Command {
      */
     public RemoveProjectCommand(Index index, RemoveProjectDescriptor removeProjectDescriptor) {
         requireNonNull(index);
-        System.out.println("hellotest");
         this.index = index;
         this.removeProjectDescriptor = new RemoveProjectDescriptor(removeProjectDescriptor);
     }
@@ -71,7 +68,7 @@ public class RemoveProjectCommand extends Command {
         ObservableList<Project> lastShownList = model.getFilteredProjectList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
         }
 
         Project projectFieldToRemove = lastShownList.get(index.getZeroBased());
@@ -87,7 +84,7 @@ public class RemoveProjectCommand extends Command {
         return new CommandResult(String.format(MESSAGE_REMOVE_FIELD_SUCCESS, removedFieldProject));
     }
     private static Project createRemoveFieldProject(Project projectToRemoveField,
-                                                  RemoveProjectCommand.RemoveProjectDescriptor removeProjectDescriptor) {
+                     RemoveProjectCommand.RemoveProjectDescriptor removeProjectDescriptor) {
         assert projectToRemoveField != null;
 
         removeProjectDescriptor.setProject(projectToRemoveField);
@@ -124,7 +121,7 @@ public class RemoveProjectCommand extends Command {
 
     /**
      * Stores the details to remove the project with. Each non-empty field value will remove the
-     * corresponding field value of the person.
+     * corresponding field value of the project.
      */
     public static class RemoveProjectDescriptor {
         private ProjectRepoHost repoHost;
@@ -138,7 +135,6 @@ public class RemoveProjectCommand extends Command {
 
         /**
          * Copy constructor.
-         * A defensive copy of {@code languages} and {@code tags} is used internally.
          */
         public RemoveProjectDescriptor(RemoveProjectCommand.RemoveProjectDescriptor toCopy) {
             setRepoHost(toCopy.repoHost);
@@ -156,7 +152,6 @@ public class RemoveProjectCommand extends Command {
         }
 
         public void setRepoHost(ProjectRepoHost repoHost) {
-            System.out.println(repoHost);
             this.repoHost = repoHost;
         }
 
@@ -191,7 +186,6 @@ public class RemoveProjectCommand extends Command {
         }
 
         public void setDeadline(ProjectDeadline deadline) {
-            System.out.println(deadline);
             this.deadline = deadline;
         }
 

--- a/src/main/java/seedu/socket/logic/commands/RemoveProjectCommand.java
+++ b/src/main/java/seedu/socket/logic/commands/RemoveProjectCommand.java
@@ -1,0 +1,251 @@
+package seedu.socket.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.socket.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.socket.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.socket.logic.parser.CliSyntax.PREFIX_LANGUAGE;
+import static seedu.socket.logic.parser.CliSyntax.PREFIX_MEETING;
+import static seedu.socket.logic.parser.CliSyntax.PREFIX_REPO_HOST;
+import static seedu.socket.logic.parser.CliSyntax.PREFIX_REPO_NAME;
+import static seedu.socket.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.Optional;
+import java.util.Set;
+
+import javafx.collections.ObservableList;
+import seedu.socket.commons.core.Messages;
+import seedu.socket.commons.core.index.Index;
+import seedu.socket.commons.util.CollectionUtil;
+import seedu.socket.logic.commands.exceptions.CommandException;
+import seedu.socket.model.Model;
+import seedu.socket.model.person.Person;
+import seedu.socket.model.project.Project;
+import seedu.socket.model.project.ProjectDeadline;
+import seedu.socket.model.project.ProjectMeeting;
+import seedu.socket.model.project.ProjectName;
+import seedu.socket.model.project.ProjectRepoHost;
+import seedu.socket.model.project.ProjectRepoName;
+
+/**
+ * Removes the details of an existing project in the SOCket.
+ */
+public class RemoveProjectCommand extends Command {
+
+    public static final String COMMAND_WORD = "removepj";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes the field of the project identified "
+            + "by the index number used in the displayed project list. "
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_REPO_HOST + "[REPO HOST]] "
+            + "[" + PREFIX_REPO_NAME + "[REPO NAME]] "
+            + "[" + PREFIX_DEADLINE + "[DEADLINE]] "
+            + "[" + PREFIX_MEETING + "[MEETING]]\n "
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_LANGUAGE + " "
+            + PREFIX_EMAIL + "johndoe@example.com";
+
+    public static final String MESSAGE_REMOVE_FIELD_SUCCESS = "Remove field: %1$s";
+
+    public static final String MESSAGE_NOT_REMOVE = "At least one field to remove must be provided.";
+
+    public static final String MESSAGE_REMOVE_FIELD_NOT_MATCH = "The field provided does not exist in the SOCket.";
+
+    private final Index index;
+
+    private final RemoveProjectDescriptor removeProjectDescriptor;
+
+    /**
+     * @param index of the project in the filtered project list to remove
+     * @param removeProjectDescriptor details to remove from the project
+     */
+    public RemoveProjectCommand(Index index, RemoveProjectDescriptor removeProjectDescriptor) {
+        requireNonNull(index);
+        System.out.println("hellotest");
+        this.index = index;
+        this.removeProjectDescriptor = new RemoveProjectDescriptor(removeProjectDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        ObservableList<Project> lastShownList = model.getFilteredProjectList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Project projectFieldToRemove = lastShownList.get(index.getZeroBased());
+        Project removedFieldProject = createRemoveFieldProject(projectFieldToRemove, removeProjectDescriptor);
+
+        if (!removeProjectDescriptor.isAnyFieldRemoved()) {
+            throw new CommandException(MESSAGE_REMOVE_FIELD_NOT_MATCH);
+        }
+
+        model.setProject(projectFieldToRemove, removedFieldProject);
+        model.commitSocket();
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_REMOVE_FIELD_SUCCESS, removedFieldProject));
+    }
+    private static Project createRemoveFieldProject(Project projectToRemoveField,
+                                                  RemoveProjectCommand.RemoveProjectDescriptor removeProjectDescriptor) {
+        assert projectToRemoveField != null;
+
+        removeProjectDescriptor.setProject(projectToRemoveField);
+
+        ProjectName defaultName = projectToRemoveField.getName();
+        ProjectRepoHost updatedRepoHost = removeProjectDescriptor.getRemoveRepoHost()
+                .orElse(projectToRemoveField.getRepoHost());
+        ProjectRepoName updatedRepoName = removeProjectDescriptor.getRemoveRepoName()
+                .orElse(projectToRemoveField.getRepoName());
+        ProjectDeadline updatedDeadline = removeProjectDescriptor.getRemoveDeadline()
+                .orElse(projectToRemoveField.getDeadline());
+        ProjectMeeting updatedMeeting = removeProjectDescriptor.getRemoveMeeting()
+                .orElse(projectToRemoveField.getMeeting());
+        Set<Person> members = projectToRemoveField.getMembers();
+        return new Project(defaultName, updatedRepoHost, updatedRepoName, updatedDeadline, updatedMeeting, members);
+    }
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RemoveProjectCommand)) {
+            return false;
+        }
+
+        // state check
+        RemoveProjectCommand e = (RemoveProjectCommand) other;
+        return index.equals(e.index)
+                && removeProjectDescriptor.equals(e.removeProjectDescriptor);
+    }
+
+    /**
+     * Stores the details to remove the project with. Each non-empty field value will remove the
+     * corresponding field value of the person.
+     */
+    public static class RemoveProjectDescriptor {
+        private ProjectRepoHost repoHost;
+        private ProjectRepoName repoName;
+        private ProjectMeeting meeting;
+        private ProjectDeadline deadline;
+
+        private Project project;
+
+        public RemoveProjectDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code languages} and {@code tags} is used internally.
+         */
+        public RemoveProjectDescriptor(RemoveProjectCommand.RemoveProjectDescriptor toCopy) {
+            setRepoHost(toCopy.repoHost);
+            setRepoName(toCopy.repoName);
+            setDeadline(toCopy.deadline);
+            setMeeting(toCopy.meeting);
+        }
+
+        public boolean isAnyFieldRemoved() {
+            return CollectionUtil.isAnyNonNull(repoHost, repoName, deadline, meeting);
+        }
+
+        public void setProject(Project project) {
+            this.project = project;
+        }
+
+        public void setRepoHost(ProjectRepoHost repoHost) {
+            System.out.println(repoHost);
+            this.repoHost = repoHost;
+        }
+
+        public Optional<ProjectRepoHost> getRemoveRepoHost() {
+            if (repoHost == null || project == null) {
+                return Optional.empty();
+            }
+
+            if (!repoHost.equals(project.getRepoHost()) && !repoHost.isEmptyRepoHost()) {
+                setRepoHost(null);
+                return Optional.empty();
+            }
+
+            return Optional.of(new ProjectRepoHost(""));
+        }
+
+        public void setRepoName(ProjectRepoName repoName) {
+            this.repoName = repoName;
+        }
+
+        public Optional<ProjectRepoName> getRemoveRepoName() {
+            if (repoName == null || project == null) {
+                return Optional.empty();
+            }
+
+            if (!repoName.equals(project.getRepoName()) && !repoName.isEmptyRepoName()) {
+                setRepoName(null);
+                return Optional.empty();
+            }
+
+            return Optional.of(new ProjectRepoName(""));
+        }
+
+        public void setDeadline(ProjectDeadline deadline) {
+            System.out.println(deadline);
+            this.deadline = deadline;
+        }
+
+        public Optional<ProjectDeadline> getRemoveDeadline() {
+
+            if (deadline == null || project == null) {
+                return Optional.empty();
+            }
+
+            if (!deadline.equals(project.getDeadline()) && !deadline.isEmptyDeadline()) {
+                setDeadline(null);
+                return Optional.empty();
+            }
+
+            return Optional.of(new ProjectDeadline(""));
+        }
+
+        public void setMeeting(ProjectMeeting meeting) {
+            this.meeting = meeting;
+        }
+
+        public Optional<ProjectMeeting> getRemoveMeeting() {
+            if (meeting == null || project == null) {
+                return Optional.empty();
+            }
+
+            if (!meeting.equals(project.getMeeting()) && !meeting.isEmptyMeeting()) {
+                setMeeting(null);
+                return Optional.empty();
+            }
+
+            return Optional.of(new ProjectMeeting(""));
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof RemoveProjectCommand.RemoveProjectDescriptor)) {
+                return false;
+            }
+
+            // state check
+            RemoveProjectCommand.RemoveProjectDescriptor e = (RemoveProjectCommand.RemoveProjectDescriptor) other;
+
+            return getRemoveRepoHost().equals(e.getRemoveRepoHost())
+                    && getRemoveRepoName().equals(e.getRemoveRepoName())
+                    && getRemoveDeadline().equals(e.getRemoveDeadline())
+                    && getRemoveMeeting().equals(e.getRemoveMeeting());
+        }
+    }
+}
+

--- a/src/main/java/seedu/socket/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/socket/logic/parser/ParserUtil.java
@@ -221,7 +221,7 @@ public class ParserUtil {
      * Parses a {@code String name} into a {@code ProjectDeadline}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code name} is invalid.
+     * @throws ParseException if the given {@code deadline} is invalid.
      */
     public static ProjectDeadline parseDeadline(String deadline) throws ParseException {
         requireNonNull(deadline);

--- a/src/main/java/seedu/socket/logic/parser/RemoveProjectCommandParser.java
+++ b/src/main/java/seedu/socket/logic/parser/RemoveProjectCommandParser.java
@@ -1,0 +1,59 @@
+package seedu.socket.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.socket.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.socket.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.socket.logic.parser.CliSyntax.PREFIX_MEETING;
+import static seedu.socket.logic.parser.CliSyntax.PREFIX_REPO_HOST;
+import static seedu.socket.logic.parser.CliSyntax.PREFIX_REPO_NAME;
+
+import seedu.socket.commons.core.index.Index;
+import seedu.socket.logic.commands.RemoveProjectCommand;
+import seedu.socket.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new RemoveProjectCommand object
+ */
+public class RemoveProjectCommandParser implements Parser<RemoveProjectCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the RemoveProjectCommand
+     * and returns an RemoveProjectCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public RemoveProjectCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_REPO_HOST, PREFIX_REPO_NAME, PREFIX_DEADLINE, PREFIX_MEETING);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RemoveProjectCommand.MESSAGE_USAGE), pe);
+        }
+
+        RemoveProjectCommand.RemoveProjectDescriptor removeProjectDescriptor =
+                new RemoveProjectCommand.RemoveProjectDescriptor();
+        if (argMultimap.getValue(PREFIX_REPO_HOST).isPresent()) {
+            removeProjectDescriptor.setRepoHost(ParserUtil.parseRepoHost(argMultimap.getValue(PREFIX_REPO_HOST).get()));
+        }
+        if (argMultimap.getValue(PREFIX_REPO_NAME).isPresent()) {
+            removeProjectDescriptor.setRepoName(ParserUtil.parseRepoName(argMultimap.getValue(PREFIX_REPO_NAME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DEADLINE).isPresent()) {
+            removeProjectDescriptor.setDeadline(ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_DEADLINE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_MEETING).isPresent()) {
+            removeProjectDescriptor.setMeeting(ParserUtil.parseMeeting(argMultimap.getValue(PREFIX_MEETING).get()));
+        }
+
+        if (!removeProjectDescriptor.isAnyFieldRemoved()) {
+            throw new ParseException(RemoveProjectCommand.MESSAGE_NOT_REMOVE);
+        }
+
+        return new RemoveProjectCommand(index, removeProjectDescriptor);
+    }
+}

--- a/src/main/java/seedu/socket/logic/parser/SocketParser.java
+++ b/src/main/java/seedu/socket/logic/parser/SocketParser.java
@@ -20,6 +20,7 @@ import seedu.socket.logic.commands.HelpCommand;
 import seedu.socket.logic.commands.ListCommand;
 import seedu.socket.logic.commands.RedoCommand;
 import seedu.socket.logic.commands.RemoveCommand;
+import seedu.socket.logic.commands.RemoveProjectCommand;
 import seedu.socket.logic.commands.SortCommand;
 import seedu.socket.logic.commands.SortProjectCommand;
 import seedu.socket.logic.commands.UndoCommand;
@@ -89,7 +90,8 @@ public class SocketParser {
 
         case SortProjectCommand.COMMAND_WORD:
             return new SortProjectCommandParser().parse(arguments);
-
+        case RemoveProjectCommand.COMMAND_WORD:
+            return new RemoveProjectCommandParser().parse(arguments);
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();
 

--- a/src/main/java/seedu/socket/model/project/ProjectDeadline.java
+++ b/src/main/java/seedu/socket/model/project/ProjectDeadline.java
@@ -34,7 +34,7 @@ public class ProjectDeadline {
      * @return true if {@code String} is of valid DateTime format, else false.
      */
     public static Boolean isValidProjectDeadline(String test) {
-        if (test == "") {
+        if (test.equals("")) {
             return true;
         }
         try {

--- a/src/main/java/seedu/socket/model/project/ProjectDeadline.java
+++ b/src/main/java/seedu/socket/model/project/ProjectDeadline.java
@@ -46,6 +46,15 @@ public class ProjectDeadline {
     }
 
     /**
+     * Returns true if deadline is empty.
+     *
+     * @return {@code true} if deadline is empty.
+     */
+    public boolean isEmptyDeadline() {
+        return deadline.equals("");
+    }
+
+    /**
      * Returns a {@code LocalDateTime} object if {@code deadline} is not empty.
      *
      * @return {@code LocalDateTime} object parsed from the stored {@code String deadline}.

--- a/src/main/java/seedu/socket/model/project/ProjectMeeting.java
+++ b/src/main/java/seedu/socket/model/project/ProjectMeeting.java
@@ -34,7 +34,7 @@ public class ProjectMeeting {
      * @return true if {@code String} is of valid DateTime format, else false.
      */
     public static Boolean isValidProjectMeeting(String test) {
-        if (test == "") {
+        if (test.equals("")) {
             return true;
         }
         try {

--- a/src/main/java/seedu/socket/model/project/ProjectMeeting.java
+++ b/src/main/java/seedu/socket/model/project/ProjectMeeting.java
@@ -46,6 +46,14 @@ public class ProjectMeeting {
     }
 
     /**
+     * Returns true if meeting is empty.
+     *
+     * @return {@code true} if meeting is empty.
+     */
+    public boolean isEmptyMeeting() {
+        return meeting.equals("");
+    }
+    /**
      * Returns a {@code LocalDateTime} object if {@code meeting} is not empty.
      *
      * @return {@code LocalDateTime} object parsed from the stored {@code String meeting}.

--- a/src/test/java/seedu/socket/logic/commands/EditProjectCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/EditProjectCommandTest.java
@@ -46,7 +46,7 @@ public class EditProjectCommandTest {
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Set<Person> members = model.getFilteredProjectList().get(0).getMembers();
-        Project editedProject = new ProjectBuilder().putMembers(members).build();
+        Project editedProject = new ProjectBuilder().withMembers(members).build();
         EditProjectCommand.EditProjectDescriptor descriptor = new EditProjectDescriptorBuilder(editedProject).build();
         EditProjectCommand editProjectCommand = new EditProjectCommand(INDEX_FIRST_PROJECT, descriptor);
 
@@ -126,7 +126,7 @@ public class EditProjectCommandTest {
         EditProjectCommand editProjectCommand = new EditProjectCommand(INDEX_FIRST_PROJECT,
                 new EditProjectDescriptorBuilder(projectInList).build());
 
-        assertCommandFailure(editProjectCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editProjectCommand, model, EditProjectCommand.MESSAGE_DUPLICATE_PROJECT);
     }
 
     @Test

--- a/src/test/java/seedu/socket/logic/commands/RemoveProjectCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/RemoveProjectCommandTest.java
@@ -1,0 +1,196 @@
+package seedu.socket.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.socket.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.socket.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.socket.logic.commands.CommandTestUtil.showProjectAtIndex;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_SECOND_PROJECT;
+import static seedu.socket.testutil.TypicalProjects.getTypicalSocket;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.socket.commons.core.Messages;
+import seedu.socket.commons.core.index.Index;
+import seedu.socket.logic.commands.RemoveProjectCommand.RemoveProjectDescriptor;
+import seedu.socket.model.Model;
+import seedu.socket.model.ModelManager;
+import seedu.socket.model.Socket;
+import seedu.socket.model.UserPrefs;
+import seedu.socket.model.project.Project;
+import seedu.socket.testutil.ProjectBuilder;
+import seedu.socket.testutil.RemoveProjectDescriptorBuilder;
+import seedu.socket.testutil.TypicalProjects;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for RemoveProjectCommand.
+ */
+public class RemoveProjectCommandTest {
+
+    private Model model = new ModelManager(getTypicalSocket(), new UserPrefs());
+    private Model modelWithProjects = new ModelManager(TypicalProjects.getTypicalSocket(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastProject = Index.fromOneBased(model.getFilteredProjectList().size());
+        Project lastProject = model.getFilteredProjectList().get(indexLastProject.getZeroBased());
+        ProjectBuilder projectInList = new ProjectBuilder().withName("Charlie Project");
+        Project removedFieldProject = projectInList.withMembers(lastProject.getMembers()).build();
+
+        RemoveProjectDescriptor descriptor = new RemoveProjectDescriptorBuilder()
+                .withProject(lastProject)
+                .withRepoHost("benson-meier")
+                .withRepoName("CharlieRepo")
+                .withDeadline("03/01/23-2359")
+                .withMeeting("03/01/23-1000").build();
+
+        RemoveProjectCommand removeProjectCommand = new RemoveProjectCommand(indexLastProject, descriptor);
+
+        String expectedMessage = String.format(RemoveProjectCommand.MESSAGE_REMOVE_FIELD_SUCCESS, removedFieldProject);
+
+        Model expectedModel = new ModelManager(new Socket(model.getSocket()), new UserPrefs());
+        expectedModel.setProject(lastProject, removedFieldProject);
+
+        assertCommandSuccess(removeProjectCommand, model, expectedMessage, expectedModel);
+    }
+
+    /**
+     * Test when user only inputs prefix
+     */
+    @Test
+    public void execute_allFieldsNotSpecifiedUnfilteredList_success() {
+        Index indexLastProject = Index.fromOneBased(model.getFilteredProjectList().size());
+        Project lastProject = model.getFilteredProjectList().get(indexLastProject.getZeroBased());
+        ProjectBuilder projectInList = new ProjectBuilder().withName("Charlie Project");
+        Project removedFieldProject = projectInList.withMembers(lastProject.getMembers()).build();
+
+        RemoveProjectDescriptor descriptor = new RemoveProjectDescriptorBuilder()
+                .withProject(lastProject)
+                .withRepoHost("")
+                .withRepoName("")
+                .withDeadline("")
+                .withMeeting("").build();
+
+        RemoveProjectCommand removeProjectCommand = new RemoveProjectCommand(indexLastProject, descriptor);
+
+        String expectedMessage = String.format(RemoveProjectCommand.MESSAGE_REMOVE_FIELD_SUCCESS, removedFieldProject);
+
+        Model expectedModel = new ModelManager(new Socket(model.getSocket()), new UserPrefs());
+        expectedModel.setProject(lastProject, removedFieldProject);
+
+        assertCommandSuccess(removeProjectCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastProject = Index.fromOneBased(model.getFilteredProjectList().size());
+        Project lastProject = model.getFilteredProjectList().get(indexLastProject.getZeroBased());
+
+        ProjectBuilder projectInList = new ProjectBuilder();
+        Project removedFieldProject = projectInList.withName("Charlie Project")
+                .withProjectDeadline("03/01/23-2359")
+                .withProjectMeeting("03/01/23-1000").withMembers(lastProject.getMembers()).build();
+
+        RemoveProjectDescriptor descriptor = new RemoveProjectDescriptorBuilder()
+                .withProject(lastProject)
+                .withRepoHost("benson-meier")
+                .withRepoName("CharlieRepo").build();
+        RemoveProjectCommand removeProjectCommand = new RemoveProjectCommand(indexLastProject, descriptor);
+
+        String expectedMessage = String.format(RemoveProjectCommand.MESSAGE_REMOVE_FIELD_SUCCESS, removedFieldProject);
+
+        Model expectedModel = new ModelManager(new Socket(model.getSocket()), new UserPrefs());
+        expectedModel.setProject(lastProject, removedFieldProject);
+
+        assertCommandSuccess(removeProjectCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsNotSpecifiedUnfilteredList_success() {
+        Index indexLastProject = Index.fromOneBased(model.getFilteredProjectList().size());
+        Project lastProject = model.getFilteredProjectList().get(indexLastProject.getZeroBased());
+
+        ProjectBuilder projectInList = new ProjectBuilder();
+        Project removedFieldProject = projectInList.withName("Charlie Project")
+                .withProjectDeadline("03/01/23-2359")
+                .withProjectMeeting("03/01/23-1000").withMembers(lastProject.getMembers()).build();
+
+        RemoveProjectDescriptor descriptor = new RemoveProjectDescriptorBuilder()
+                .withProject(lastProject)
+                .withRepoHost("")
+                .withRepoName("").build();
+        RemoveProjectCommand removeProjectCommand = new RemoveProjectCommand(indexLastProject, descriptor);
+
+        String expectedMessage = String.format(RemoveProjectCommand.MESSAGE_REMOVE_FIELD_SUCCESS, removedFieldProject);
+
+        Model expectedModel = new ModelManager(new Socket(model.getSocket()), new UserPrefs());
+        expectedModel.setProject(lastProject, removedFieldProject);
+
+        assertCommandSuccess(removeProjectCommand, model, expectedMessage, expectedModel);
+    }
+
+    /**
+     * Tests when field descriptions in the project don't match field descriptions given by user.
+     */
+    @Test
+    public void execute_allDifferentFieldNotMatchUnfilteredList_failure() {
+        Index indexSecondProject = Index.fromOneBased(model.getFilteredProjectList().size() - 1);
+        Project lastProject = model.getFilteredProjectList().get(indexSecondProject.getZeroBased());
+        ProjectBuilder projectInList = new ProjectBuilder().withName("Bravo Project");
+        Project removedFieldProject = projectInList.withMembers(lastProject.getMembers()).build();
+
+        RemoveProjectDescriptor descriptor = new RemoveProjectDescriptorBuilder()
+                .withProject(lastProject)
+                .withRepoHost("benson-meier")
+                .withRepoName("CharlieRepo")
+                .withDeadline("03/01/23-2359")
+                .withMeeting("03/01/23-1000").build();
+
+        RemoveProjectCommand removeProjectCommand = new RemoveProjectCommand(indexSecondProject, descriptor);
+
+        Model expectedModel = new ModelManager(new Socket(model.getSocket()), new UserPrefs());
+        expectedModel.setProject(lastProject, removedFieldProject);
+
+        assertCommandFailure(removeProjectCommand, model, RemoveProjectCommand.MESSAGE_REMOVE_FIELD_NOT_MATCH);
+    }
+
+    @Test
+    public void execute_specificFieldNotMatchUnfilteredList_failure() {
+        Project firstProject = model.getFilteredProjectList().get(INDEX_FIRST_PROJECT.getZeroBased());
+
+        RemoveProjectDescriptor descriptor = new RemoveProjectDescriptorBuilder()
+                .withProject(firstProject)
+                .withRepoName("CharlieRepo")
+                .withRepoHost("benson-meier").build();
+        RemoveProjectCommand removeProjectCommand = new RemoveProjectCommand(INDEX_FIRST_PROJECT, descriptor);
+
+        assertCommandFailure(removeProjectCommand, model, RemoveCommand.MESSAGE_REMOVE_FIELD_NOT_MATCH);
+    }
+
+    @Test
+    public void execute_invalidProjectIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredProjectList().size() + 1);
+        RemoveProjectDescriptor descriptor = new RemoveProjectDescriptorBuilder().build();
+        RemoveProjectCommand removeProjectCommand = new RemoveProjectCommand(outOfBoundIndex, descriptor);
+
+        assertCommandFailure(removeProjectCommand, model, Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidProjectIndexFilteredList_failure() {
+        showProjectAtIndex(model, INDEX_FIRST_PROJECT);
+        Index outOfBoundIndex = INDEX_SECOND_PROJECT;
+        // ensures that outOfBoundIndex is still in bounds of project list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getSocket().getProjectList().size());
+
+        RemoveProjectCommand removeProjectCommand = new RemoveProjectCommand(outOfBoundIndex,
+                new RemoveProjectDescriptorBuilder().build());
+
+        assertCommandFailure(removeProjectCommand, model, Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+    }
+}
+

--- a/src/test/java/seedu/socket/logic/commands/RemoveProjectCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/RemoveProjectCommandTest.java
@@ -1,9 +1,14 @@
 package seedu.socket.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_MEETING_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_REPO_HOST_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_REPO_HOST_BRAVO;
 import static seedu.socket.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.socket.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.socket.logic.commands.CommandTestUtil.showProjectAtIndex;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
 import static seedu.socket.testutil.TypicalIndexes.INDEX_SECOND_PROJECT;
 import static seedu.socket.testutil.TypicalProjects.getTypicalSocket;
@@ -18,6 +23,7 @@ import seedu.socket.model.ModelManager;
 import seedu.socket.model.Socket;
 import seedu.socket.model.UserPrefs;
 import seedu.socket.model.project.Project;
+import seedu.socket.testutil.EditProjectDescriptorBuilder;
 import seedu.socket.testutil.ProjectBuilder;
 import seedu.socket.testutil.RemoveProjectDescriptorBuilder;
 import seedu.socket.testutil.TypicalProjects;
@@ -191,6 +197,40 @@ public class RemoveProjectCommandTest {
                 new RemoveProjectDescriptorBuilder().build());
 
         assertCommandFailure(removeProjectCommand, model, Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void testEquals() {
+        final RemoveProjectCommand standardCommand = new RemoveProjectCommand(INDEX_FIRST_PERSON,
+                new RemoveProjectDescriptorBuilder()
+                        .withRepoHost(VALID_PROJECT_REPO_HOST_ALPHA)
+                        .withMeeting(VALID_PROJECT_MEETING_ALPHA).build());
+
+        // same values -> returns true
+        RemoveProjectCommand.RemoveProjectDescriptor copyDescriptor =
+                new RemoveProjectCommand.RemoveProjectDescriptor(new RemoveProjectDescriptorBuilder()
+                        .withRepoHost(VALID_PROJECT_REPO_HOST_ALPHA)
+                        .withMeeting(VALID_PROJECT_MEETING_ALPHA).build());
+        RemoveProjectCommand commandWithSameValues = new RemoveProjectCommand(INDEX_FIRST_PROJECT, copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new RemoveProjectCommand(INDEX_SECOND_PROJECT,
+                new RemoveProjectDescriptorBuilder()
+                        .withRepoHost(VALID_PROJECT_REPO_HOST_ALPHA)
+                        .withMeeting(VALID_PROJECT_MEETING_ALPHA).build())));
+
+        // different descriptor same field -> returns true
+        assertTrue(standardCommand.equals(new RemoveProjectCommand(INDEX_FIRST_PROJECT,
+                new RemoveProjectDescriptorBuilder()
+                        .withRepoHost(VALID_PROJECT_REPO_HOST_BRAVO)
+                        .withMeeting(VALID_PROJECT_MEETING_ALPHA).build())));
     }
 }
 

--- a/src/test/java/seedu/socket/logic/commands/RemoveProjectCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/RemoveProjectCommandTest.java
@@ -23,7 +23,6 @@ import seedu.socket.model.ModelManager;
 import seedu.socket.model.Socket;
 import seedu.socket.model.UserPrefs;
 import seedu.socket.model.project.Project;
-import seedu.socket.testutil.EditProjectDescriptorBuilder;
 import seedu.socket.testutil.ProjectBuilder;
 import seedu.socket.testutil.RemoveProjectDescriptorBuilder;
 import seedu.socket.testutil.TypicalProjects;

--- a/src/test/java/seedu/socket/logic/commands/RemoveProjectDescriptorTest.java
+++ b/src/test/java/seedu/socket/logic/commands/RemoveProjectDescriptorTest.java
@@ -2,15 +2,17 @@ package seedu.socket.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.socket.logic.commands.CommandTestUtil.*;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_DEADLINE_BRAVO;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_MEETING_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_MEETING_BRAVO;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_REPO_HOST_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_REPO_HOST_BRAVO;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_REPO_NAME_BRAVO;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.socket.logic.commands.RemoveProjectCommand.RemoveProjectDescriptor;
-import seedu.socket.testutil.EditProjectDescriptorBuilder;
-import seedu.socket.testutil.RemovePersonDescriptorBuilder;
 import seedu.socket.testutil.RemoveProjectDescriptorBuilder;
-import seedu.socket.testutil.TypicalPersons;
 
 public class RemoveProjectDescriptorTest {
 
@@ -39,14 +41,15 @@ public class RemoveProjectDescriptorTest {
 
         // different values but same fields -> returns true
         assertTrue(descAlpha.equals(descBravo));
-        assert false;
+
         // different repo host -> returns true
         RemoveProjectDescriptor removedAlpha = new RemoveProjectDescriptorBuilder(descAlpha)
                 .withRepoHost(VALID_PROJECT_REPO_HOST_BRAVO).build();
-        assertFalse(descAlpha.equals(removedAlpha));
+        assertTrue(descAlpha.equals(removedAlpha));
 
         // add repo name -> returns true
-        removedAlpha = new RemoveProjectDescriptorBuilder(descAlpha).withRepoName(VALID_PROJECT_REPO_NAME_BRAVO).build();
+        removedAlpha = new RemoveProjectDescriptorBuilder(descAlpha)
+                .withRepoName(VALID_PROJECT_REPO_NAME_BRAVO).build();
         assertTrue(descAlpha.equals(removedAlpha));
 
         // different deadline -> returns true

--- a/src/test/java/seedu/socket/logic/commands/RemoveProjectDescriptorTest.java
+++ b/src/test/java/seedu/socket/logic/commands/RemoveProjectDescriptorTest.java
@@ -1,0 +1,60 @@
+package seedu.socket.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.socket.logic.commands.CommandTestUtil.*;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.socket.logic.commands.RemoveProjectCommand.RemoveProjectDescriptor;
+import seedu.socket.testutil.EditProjectDescriptorBuilder;
+import seedu.socket.testutil.RemovePersonDescriptorBuilder;
+import seedu.socket.testutil.RemoveProjectDescriptorBuilder;
+import seedu.socket.testutil.TypicalPersons;
+
+public class RemoveProjectDescriptorTest {
+
+    final RemoveProjectCommand.RemoveProjectDescriptor descAlpha = new RemoveProjectDescriptorBuilder()
+            .withRepoHost(VALID_PROJECT_REPO_HOST_ALPHA)
+            .withMeeting(VALID_PROJECT_MEETING_ALPHA).build();
+
+    final RemoveProjectCommand.RemoveProjectDescriptor descBravo = new RemoveProjectDescriptorBuilder()
+            .withRepoHost(VALID_PROJECT_REPO_HOST_BRAVO)
+            .withMeeting(VALID_PROJECT_MEETING_BRAVO).build();
+    @Test
+    public void equals() {
+
+        // same values -> returns true
+        RemoveProjectDescriptor descriptorWithSameValues = new RemoveProjectDescriptor(descAlpha);
+        assertTrue(descAlpha.equals(descriptorWithSameValues));
+
+        // same object -> returns true
+        assertTrue(descAlpha.equals(descAlpha));
+
+        // null -> returns false
+        assertFalse(descAlpha.equals(null));
+
+        // different types -> returns false
+        assertFalse(descAlpha.equals(5));
+
+        // different values but same fields -> returns true
+        assertTrue(descAlpha.equals(descBravo));
+        assert false;
+        // different repo host -> returns true
+        RemoveProjectDescriptor removedAlpha = new RemoveProjectDescriptorBuilder(descAlpha)
+                .withRepoHost(VALID_PROJECT_REPO_HOST_BRAVO).build();
+        assertFalse(descAlpha.equals(removedAlpha));
+
+        // add repo name -> returns true
+        removedAlpha = new RemoveProjectDescriptorBuilder(descAlpha).withRepoName(VALID_PROJECT_REPO_NAME_BRAVO).build();
+        assertTrue(descAlpha.equals(removedAlpha));
+
+        // different deadline -> returns true
+        removedAlpha = new RemoveProjectDescriptorBuilder(descAlpha).withDeadline(VALID_PROJECT_DEADLINE_BRAVO).build();
+        assertTrue(descAlpha.equals(removedAlpha));
+
+        // different meeting -> returns true
+        removedAlpha = new RemoveProjectDescriptorBuilder(descAlpha).withMeeting(VALID_PROJECT_MEETING_BRAVO).build();
+        assertTrue(descBravo.equals(removedAlpha));
+    }
+}

--- a/src/test/java/seedu/socket/logic/parser/RemoveProjectCommandParserTest.java
+++ b/src/test/java/seedu/socket/logic/parser/RemoveProjectCommandParserTest.java
@@ -32,7 +32,8 @@ import seedu.socket.model.project.ProjectRepoHost;
 import seedu.socket.model.project.ProjectRepoName;
 import seedu.socket.testutil.RemoveProjectDescriptorBuilder;
 
-public class RemoveProjectCommandParserTest {private static final String MESSAGE_INVALID_FORMAT =
+public class RemoveProjectCommandParserTest {
+    private static final String MESSAGE_INVALID_FORMAT =
         String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveProjectCommand.MESSAGE_USAGE);
 
     private RemoveProjectCommandParser parser = new RemoveProjectCommandParser();
@@ -66,9 +67,13 @@ public class RemoveProjectCommandParserTest {private static final String MESSAGE
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_REPO_HOST_DESC, ProjectRepoHost.MESSAGE_CONSTRAINTS); // invalid profile
-        assertParseFailure(parser, "1" + INVALID_REPO_NAME_DESC, ProjectRepoName.MESSAGE_CONSTRAINTS); // invalid phone
-        assertParseFailure(parser, "1" + INVALID_DEADLINE_DESC, ProjectDeadline.MESSAGE_CONSTRAINTS); // invalid email
+        // invalid repo host
+        assertParseFailure(parser, "1" + INVALID_REPO_HOST_DESC, ProjectRepoHost.MESSAGE_CONSTRAINTS);
+        // invalid repo name
+        assertParseFailure(parser, "1" + INVALID_REPO_NAME_DESC, ProjectRepoName.MESSAGE_CONSTRAINTS);
+        // invalid deadline
+        assertParseFailure(parser, "1" + INVALID_DEADLINE_DESC, ProjectDeadline.MESSAGE_CONSTRAINTS);
+        // invalid meeting
         assertParseFailure(parser, "1" + INVALID_MEETING_DESC, ProjectMeeting.MESSAGE_CONSTRAINTS);
     }
 

--- a/src/test/java/seedu/socket/logic/parser/RemoveProjectCommandParserTest.java
+++ b/src/test/java/seedu/socket/logic/parser/RemoveProjectCommandParserTest.java
@@ -1,0 +1,153 @@
+package seedu.socket.logic.parser;
+
+import static seedu.socket.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.socket.logic.commands.CommandTestUtil.DEADLINE_DESC_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.INVALID_DEADLINE_DESC;
+import static seedu.socket.logic.commands.CommandTestUtil.INVALID_MEETING_DESC;
+import static seedu.socket.logic.commands.CommandTestUtil.INVALID_REPO_HOST_DESC;
+import static seedu.socket.logic.commands.CommandTestUtil.INVALID_REPO_NAME_DESC;
+import static seedu.socket.logic.commands.CommandTestUtil.MEETING_DESC_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.PROJECT_NAME_DESC_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.REPO_HOST_DESC_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.REPO_NAME_DESC_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_DEADLINE_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_MEETING_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_NAME_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_REPO_HOST_ALPHA;
+import static seedu.socket.logic.commands.CommandTestUtil.VALID_PROJECT_REPO_NAME_ALPHA;
+import static seedu.socket.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.socket.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_SECOND_PROJECT;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_THIRD_PROJECT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.socket.commons.core.index.Index;
+import seedu.socket.logic.commands.RemoveProjectCommand;
+import seedu.socket.logic.commands.RemoveProjectCommand.RemoveProjectDescriptor;
+import seedu.socket.model.project.ProjectDeadline;
+import seedu.socket.model.project.ProjectMeeting;
+import seedu.socket.model.project.ProjectRepoHost;
+import seedu.socket.model.project.ProjectRepoName;
+import seedu.socket.testutil.RemoveProjectDescriptorBuilder;
+
+public class RemoveProjectCommandParserTest {private static final String MESSAGE_INVALID_FORMAT =
+        String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveProjectCommand.MESSAGE_USAGE);
+
+    private RemoveProjectCommandParser parser = new RemoveProjectCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_PROJECT_NAME_ALPHA, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "1", RemoveProjectCommand.MESSAGE_NOT_REMOVE);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + PROJECT_NAME_DESC_ALPHA, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + PROJECT_NAME_DESC_ALPHA, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1" + INVALID_REPO_HOST_DESC, ProjectRepoHost.MESSAGE_CONSTRAINTS); // invalid profile
+        assertParseFailure(parser, "1" + INVALID_REPO_NAME_DESC, ProjectRepoName.MESSAGE_CONSTRAINTS); // invalid phone
+        assertParseFailure(parser, "1" + INVALID_DEADLINE_DESC, ProjectDeadline.MESSAGE_CONSTRAINTS); // invalid email
+        assertParseFailure(parser, "1" + INVALID_MEETING_DESC, ProjectMeeting.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        Index targetIndex = INDEX_SECOND_PROJECT;
+        String userInput = targetIndex.getOneBased() + REPO_HOST_DESC_ALPHA + REPO_NAME_DESC_ALPHA + DEADLINE_DESC_ALPHA
+                + MEETING_DESC_ALPHA;
+
+        RemoveProjectDescriptor descriptor = new RemoveProjectDescriptorBuilder()
+                .withRepoHost(VALID_PROJECT_REPO_HOST_ALPHA).withRepoName(VALID_PROJECT_REPO_NAME_ALPHA)
+                .withDeadline(VALID_PROJECT_DEADLINE_ALPHA)
+                .withMeeting(VALID_PROJECT_MEETING_ALPHA).build();
+        RemoveProjectCommand expectedCommand = new RemoveProjectCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_someFieldsSpecified_success() {
+        Index targetIndex = INDEX_FIRST_PROJECT;
+        String userInput = targetIndex.getOneBased() + MEETING_DESC_ALPHA + DEADLINE_DESC_ALPHA;
+
+        RemoveProjectDescriptor descriptor = new RemoveProjectDescriptorBuilder()
+                .withDeadline(VALID_PROJECT_DEADLINE_ALPHA)
+                .withMeeting(VALID_PROJECT_MEETING_ALPHA).build();
+        RemoveProjectCommand expectedCommand = new RemoveProjectCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_oneFieldSpecified_success() {
+        // repo host
+        Index targetIndex = INDEX_THIRD_PROJECT;
+        String userInput = targetIndex.getOneBased() + REPO_HOST_DESC_ALPHA;
+        RemoveProjectDescriptor descriptor = new RemoveProjectDescriptorBuilder()
+                .withRepoHost(VALID_PROJECT_REPO_HOST_ALPHA).build();
+        RemoveProjectCommand expectedCommand = new RemoveProjectCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // repo name
+        userInput = targetIndex.getOneBased() + REPO_NAME_DESC_ALPHA;
+        descriptor = new RemoveProjectDescriptorBuilder()
+                .withRepoName(VALID_PROJECT_REPO_NAME_ALPHA).build();
+        expectedCommand = new RemoveProjectCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // deadline
+        userInput = targetIndex.getOneBased() + DEADLINE_DESC_ALPHA;
+        descriptor = new RemoveProjectDescriptorBuilder()
+                .withDeadline(VALID_PROJECT_DEADLINE_ALPHA).build();
+        expectedCommand = new RemoveProjectCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // meeting
+        userInput = targetIndex.getOneBased() + MEETING_DESC_ALPHA;
+        descriptor = new RemoveProjectDescriptorBuilder()
+                .withMeeting(VALID_PROJECT_MEETING_ALPHA).build();
+        expectedCommand = new RemoveProjectCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidValueFollowedByValidValue_success() {
+        // no other valid values specified
+        Index targetIndex = INDEX_FIRST_PROJECT;
+        String userInput = targetIndex.getOneBased() + INVALID_REPO_HOST_DESC + REPO_HOST_DESC_ALPHA;
+        RemoveProjectDescriptor descriptor = new RemoveProjectDescriptorBuilder()
+                .withRepoName(VALID_PROJECT_REPO_HOST_ALPHA).build();
+        RemoveProjectCommand expectedCommand = new RemoveProjectCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // other valid values specified
+        userInput = targetIndex.getOneBased() + INVALID_REPO_HOST_DESC + MEETING_DESC_ALPHA + REPO_HOST_DESC_ALPHA;
+        descriptor = new RemoveProjectDescriptorBuilder().withRepoHost(VALID_PROJECT_REPO_HOST_ALPHA)
+                .withMeeting(VALID_PROJECT_MEETING_ALPHA).build();
+        expectedCommand = new RemoveProjectCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}
+

--- a/src/test/java/seedu/socket/logic/parser/SocketParserTest.java
+++ b/src/test/java/seedu/socket/logic/parser/SocketParserTest.java
@@ -54,6 +54,7 @@ import seedu.socket.logic.commands.ListCommand;
 import seedu.socket.logic.commands.RedoCommand;
 import seedu.socket.logic.commands.RemoveCommand;
 import seedu.socket.logic.commands.RemoveCommand.RemovePersonDescriptor;
+import seedu.socket.logic.commands.RemoveProjectCommand;
 import seedu.socket.logic.commands.SortCommand;
 import seedu.socket.logic.commands.SortProjectCommand;
 import seedu.socket.logic.commands.UndoCommand;
@@ -68,6 +69,7 @@ import seedu.socket.testutil.PersonBuilder;
 import seedu.socket.testutil.PersonUtil;
 import seedu.socket.testutil.ProjectBuilder;
 import seedu.socket.testutil.RemovePersonDescriptorBuilder;
+import seedu.socket.testutil.RemoveProjectDescriptorBuilder;
 
 public class SocketParserTest {
 
@@ -275,6 +277,21 @@ public class SocketParserTest {
         RemoveCommand command = (RemoveCommand) parser.parseCommand(RemoveCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getRemovePersonDescriptorDetails(descriptor));
         assertEquals(new RemoveCommand(INDEX_FIRST_PERSON, descriptor), command);
+    }
+    @Test
+    public void parseCommand_removepj() throws Exception {
+        Project project = new ProjectBuilder().withName(VALID_PROJECT_NAME_ALPHA)
+                .withRepoHost(VALID_PROJECT_REPO_HOST_ALPHA)
+                .withRepoName(VALID_PROJECT_REPO_NAME_ALPHA)
+                .withProjectDeadline(VALID_PROJECT_DEADLINE_ALPHA)
+                .withProjectMeeting(VALID_PROJECT_MEETING_ALPHA)
+                .build();
+        RemoveProjectCommand.RemoveProjectDescriptor descriptor = new RemoveProjectDescriptorBuilder(project).build();
+        RemoveProjectCommand command = (RemoveProjectCommand) parser.parseCommand(RemoveProjectCommand.COMMAND_WORD
+                + " "
+                + INDEX_FIRST_PROJECT.getOneBased() + " " + REPO_NAME_DESC_ALPHA
+                + REPO_HOST_DESC_ALPHA + DEADLINE_DESC_ALPHA + MEETING_DESC_ALPHA);
+        assertEquals(new RemoveProjectCommand(INDEX_FIRST_PROJECT, descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/socket/testutil/ProjectBuilder.java
+++ b/src/test/java/seedu/socket/testutil/ProjectBuilder.java
@@ -106,7 +106,7 @@ public class ProjectBuilder {
     /**
      * Sets the {@code members} to the {@code Project} that we are building.
      */
-    public ProjectBuilder putMembers(Set<Person> members) {
+    public ProjectBuilder withMembers(Set<Person> members) {
         this.members = members;
         return this;
     }

--- a/src/test/java/seedu/socket/testutil/RemoveProjectDescriptorBuilder.java
+++ b/src/test/java/seedu/socket/testutil/RemoveProjectDescriptorBuilder.java
@@ -51,7 +51,7 @@ public class RemoveProjectDescriptorBuilder {
     }
 
     /**
-     * Sets the {@code repoName} of the {@code EditProjectDescriptor} that we are building.
+     * Sets the {@code repoName} of the {@code RemoveProjectDescriptor} that we are building.
      */
     public RemoveProjectDescriptorBuilder withRepoName(String repoName) {
         descriptor.setRepoName(new ProjectRepoName(repoName));
@@ -59,7 +59,7 @@ public class RemoveProjectDescriptorBuilder {
     }
 
     /**
-     * Sets the {@code deadline} of the {@code EditProjectDescriptor} that we are building.
+     * Sets the {@code deadline} of the {@code RemoveProjectDescriptor} that we are building.
      */
     public RemoveProjectDescriptorBuilder withDeadline(String deadline) {
         descriptor.setDeadline(new ProjectDeadline(deadline));
@@ -67,7 +67,7 @@ public class RemoveProjectDescriptorBuilder {
     }
 
     /**
-     * Sets the {@code meeting} of the {@code EditProjectDescriptor} that we are building.
+     * Sets the {@code meeting} of the {@code RemoveProjectDescriptor} that we are building.
      */
     public RemoveProjectDescriptorBuilder withMeeting(String meeting) {
         descriptor.setMeeting(new ProjectMeeting(meeting));

--- a/src/test/java/seedu/socket/testutil/RemoveProjectDescriptorBuilder.java
+++ b/src/test/java/seedu/socket/testutil/RemoveProjectDescriptorBuilder.java
@@ -1,0 +1,82 @@
+package seedu.socket.testutil;
+
+import seedu.socket.logic.commands.RemoveProjectCommand.RemoveProjectDescriptor;
+import seedu.socket.model.project.Project;
+import seedu.socket.model.project.ProjectDeadline;
+import seedu.socket.model.project.ProjectMeeting;
+import seedu.socket.model.project.ProjectRepoHost;
+import seedu.socket.model.project.ProjectRepoName;
+
+/**
+ * A utility class to help with building RemoveProjectDescriptor objects.
+ */
+public class RemoveProjectDescriptorBuilder {
+
+    private RemoveProjectDescriptor descriptor;
+
+    public RemoveProjectDescriptorBuilder() {
+        descriptor = new RemoveProjectDescriptor();
+    }
+
+    public RemoveProjectDescriptorBuilder(RemoveProjectDescriptor descriptor) {
+        this.descriptor = new RemoveProjectDescriptor(descriptor);
+    }
+
+    /**
+     * Sets an {@code RemoveProjectDescriptor} with fields containing {@code project}'s details
+     */
+    public RemoveProjectDescriptorBuilder(Project project) {
+        descriptor = new RemoveProjectDescriptor();
+        descriptor.setProject(project);
+        descriptor.setRepoHost(project.getRepoHost());
+        descriptor.setRepoName(project.getRepoName());
+        descriptor.setDeadline(project.getDeadline());
+        descriptor.setMeeting(project.getMeeting());
+    }
+
+    /**
+     * Sets the {@code person} of the {@code RemoveProjectDescriptor} that we are building.
+     */
+    public RemoveProjectDescriptorBuilder withProject(Project project) {
+        descriptor.setProject(project);
+        return this;
+    }
+
+    /**
+     * Sets the {@code repoHost} of the {@code EditProjectDescriptor} that we are building.
+     */
+    public RemoveProjectDescriptorBuilder withRepoHost(String repoHost) {
+        descriptor.setRepoHost(new ProjectRepoHost(repoHost));
+        return this;
+    }
+
+    /**
+     * Sets the {@code repoName} of the {@code EditProjectDescriptor} that we are building.
+     */
+    public RemoveProjectDescriptorBuilder withRepoName(String repoName) {
+        descriptor.setRepoName(new ProjectRepoName(repoName));
+        return this;
+    }
+
+    /**
+     * Sets the {@code deadline} of the {@code EditProjectDescriptor} that we are building.
+     */
+    public RemoveProjectDescriptorBuilder withDeadline(String deadline) {
+        descriptor.setDeadline(new ProjectDeadline(deadline));
+        return this;
+    }
+
+    /**
+     * Sets the {@code meeting} of the {@code EditProjectDescriptor} that we are building.
+     */
+    public RemoveProjectDescriptorBuilder withMeeting(String meeting) {
+        descriptor.setMeeting(new ProjectMeeting(meeting));
+        return this;
+    }
+
+    public RemoveProjectDescriptor build() {
+        return descriptor;
+    }
+
+}
+


### PR DESCRIPTION
Previous implementation does not have  have feature to remove project, removepj is added so that user can remove fields in a specific project. 

**RemoveProjectCommand.java**
- Removes field from project

**RemoveProjectCommandParser.java**
- Parses user input when they want to remove project field 

**SocketParser.java**
- Add case for removepj

**ProjectDeadline.java**
- Change equality operator to equals()

**ProjecMeeting.java**
- Change equality operator to equals()

**EditProjectCommand.java**

- Fix error message 

**ParserUtil.java**
- Fix javadoc

**RemoveProjectCommandTest.java**
- Test RemoveProjectCommand

**RemoveProjectDescriptorTest.java**
- Test RemoveProjectDescriptor 

**RemoveProjectCommandParser.java**
- Test RemoveProjectCommandParser

**SocketParserTest.java**
- Add test for removepj

**ProjectBuilder.java**
- Change method name of putMembers() to withMembers()

**RemoveProjectBuilderDescriptor.java**
- Builds a RemoveProjectBuilder for testing

**EditProjectCommandTest.java**
- Change putMembers() to withMembers()

