### PR TITLE
Add ability to assign persons to projects in SOCket

### DIFF
--- a/src/main/java/seedu/socket/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/socket/logic/commands/AssignCommand.java
@@ -1,0 +1,103 @@
+package seedu.socket.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.socket.commons.core.Messages;
+import seedu.socket.commons.core.index.Index;
+import seedu.socket.logic.commands.exceptions.CommandException;
+import seedu.socket.model.Model;
+import seedu.socket.model.person.Person;
+import seedu.socket.model.project.Project;
+
+/**
+ * Adds a person in the currently displayed list to a project in SOCket.
+ */
+public class AssignCommand extends Command {
+    public static final String COMMAND_WORD = "assign";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to a project.\n"
+            + "Person & project are identified by the index number "
+            + "used in the displayed person & project list respectively.\n"
+            + "Parameters: PERSON_INDEX (must be a positive integer) "
+            + "PROJECT_INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1 3";
+
+    public static final String MESSAGE_ASSIGN_SUCCESS = "Added %1$s to project: %2$s";
+    public static final String MESSAGE_ALREADY_IN_PROJECT = "%1$s is already a member of this project.";
+    private final Index personIndex;
+    private final Index projectIndex;
+
+    /**
+     * @param personIndex Index of the person in the person list to be added to project
+     * @param projectIndex Index of the project in the project list that person is to be added to
+     */
+    public AssignCommand(Index personIndex, Index projectIndex) {
+        requireNonNull(personIndex);
+        requireNonNull(projectIndex);
+
+        this.personIndex = personIndex;
+        this.projectIndex = projectIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownPersonList = model.getFilteredPersonList();
+        List<Project> lastShownProjectList = model.getFilteredProjectList();
+
+        // Checks if index provided is valid.
+        if (personIndex.getZeroBased() >= lastShownPersonList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        if (projectIndex.getZeroBased() >= lastShownProjectList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+        }
+
+        // Gets Project and Person to be assigned, prepares Set for transfer.
+        Person personToAssign = lastShownPersonList.get(personIndex.getZeroBased());
+        Project projectToAssign = lastShownProjectList.get(projectIndex.getZeroBased());
+        Set<Person> members = projectToAssign.getMembers();
+        Set<Person> newMembers = new HashSet<>();
+
+        // Checks if Person is already in Project.
+        if (projectToAssign.hasMember(personToAssign.getName())) {
+            throw new CommandException(String.format(MESSAGE_ALREADY_IN_PROJECT, personToAssign.getName()));
+        }
+
+        // Transfers members from old set to new set, then add new member.
+        for (Person member : members) {
+            newMembers.add(member);
+        }
+        newMembers.add(personToAssign);
+
+        // Creates new Project with updated members
+        Project editedProject = new Project(projectToAssign.getName(), projectToAssign.getRepoHost(),
+                projectToAssign.getRepoName(), projectToAssign.getDeadline(), projectToAssign.getMeeting(),
+                newMembers);
+        model.setProject(projectToAssign, editedProject);
+        return new CommandResult(String.format(
+                MESSAGE_ASSIGN_SUCCESS, personToAssign.getName(), editedProject.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AssignCommand)) {
+            return false;
+        }
+
+        // state check
+        AssignCommand e = (AssignCommand) other;
+        return personIndex.equals(e.personIndex)
+                && projectIndex.equals(e.projectIndex);
+    }
+}

--- a/src/main/java/seedu/socket/logic/parser/AssignCommandParser.java
+++ b/src/main/java/seedu/socket/logic/parser/AssignCommandParser.java
@@ -1,0 +1,51 @@
+package seedu.socket.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.socket.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.socket.commons.core.index.Index;
+import seedu.socket.logic.commands.AssignCommand;
+import seedu.socket.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AssignCommand object
+ */
+public class AssignCommandParser implements Parser<AssignCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the AssignCommand
+     * and returns an AssignCommand object for execution.
+     * @param args The user input to be parsed.
+     * @return AssignCommand The AssignCommand object to be executed.
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    public AssignCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        // Check if args is not empty.
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignCommand.MESSAGE_USAGE));
+        }
+
+        // Check if number of args is correct.
+        String[] indexArgs = trimmedArgs.split("\\s+");
+        if (indexArgs.length != 2) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignCommand.MESSAGE_USAGE));
+        }
+
+        // Parse args into Index class and return command object.
+        Index personIndex;
+        Index projectIndex;
+        try {
+            personIndex = ParserUtil.parseIndex(indexArgs[0]);
+            projectIndex = ParserUtil.parseIndex(indexArgs[1]);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AssignCommand.MESSAGE_USAGE), pe);
+        }
+
+        return new AssignCommand(personIndex, projectIndex);
+    }
+}

--- a/src/main/java/seedu/socket/logic/parser/SocketParser.java
+++ b/src/main/java/seedu/socket/logic/parser/SocketParser.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import seedu.socket.logic.commands.AddCommand;
 import seedu.socket.logic.commands.AddProjectCommand;
+import seedu.socket.logic.commands.AssignCommand;
 import seedu.socket.logic.commands.ClearCommand;
 import seedu.socket.logic.commands.ClearProjectCommand;
 import seedu.socket.logic.commands.Command;
@@ -107,6 +108,9 @@ public class SocketParser {
 
         case ClearProjectCommand.COMMAND_WORD:
             return new ClearProjectCommand();
+
+        case AssignCommand.COMMAND_WORD:
+            return new AssignCommandParser().parse(arguments);
 
         case UnassignCommand.COMMAND_WORD:
             return new UnassignCommandParser().parse(arguments);

--- a/src/test/java/seedu/socket/logic/commands/AssignCommandTest.java
+++ b/src/test/java/seedu/socket/logic/commands/AssignCommandTest.java
@@ -1,0 +1,123 @@
+package seedu.socket.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.socket.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.socket.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.socket.testutil.Assert.assertThrows;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_SECOND_PROJECT;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.socket.testutil.TypicalPersons.ALICE;
+import static seedu.socket.testutil.TypicalPersons.BENSON;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.socket.commons.core.Messages;
+import seedu.socket.commons.core.index.Index;
+import seedu.socket.model.Model;
+import seedu.socket.model.ModelManager;
+import seedu.socket.model.UserPrefs;
+import seedu.socket.model.person.Person;
+import seedu.socket.model.project.Project;
+import seedu.socket.testutil.ProjectBuilder;
+import seedu.socket.testutil.TypicalProjects;
+
+public class AssignCommandTest {
+    @Test
+    public void constructor_nullIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AssignCommand(INDEX_FIRST_PERSON, null));
+        assertThrows(NullPointerException.class, () -> new AssignCommand(null, INDEX_FIRST_PROJECT));
+        assertThrows(NullPointerException.class, () -> new AssignCommand(null, null));
+    }
+
+    @Test
+    public void execute_assign_success() {
+        Model model = new ModelManager(TypicalProjects.getTypicalSocket(), new UserPrefs());
+        // Index 0 & 1 Person are already members of target Project, hence get Index 2 is used.
+        Person targetMember = model.getFilteredPersonList().get(2);
+        Project targetProject = model.getFilteredProjectList().get(0);
+        Set<Person> newMembers = new HashSet<>();
+        newMembers.add(ALICE);
+        newMembers.add(BENSON);
+        newMembers.add(targetMember);
+        Project editedProject = new ProjectBuilder(targetProject).withMembers(newMembers).build();
+
+        Model expectedModel = new ModelManager(TypicalProjects.getTypicalSocket(), new UserPrefs());
+        expectedModel.setProject(targetProject, editedProject);
+        AssignCommand assignCommand = new AssignCommand(INDEX_THIRD_PERSON, INDEX_FIRST_PROJECT);
+        String expectedMessage = String.format(AssignCommand.MESSAGE_ASSIGN_SUCCESS, targetMember.getName(),
+                targetProject.getName());
+        assertCommandSuccess(assignCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateMember_failure() {
+        Model model = new ModelManager(TypicalProjects.getTypicalSocket(), new UserPrefs());
+        Person targetMember = ALICE;
+        AssignCommand assignCommand = new AssignCommand(INDEX_FIRST_PERSON, INDEX_FIRST_PROJECT);
+        String expectedMessage = String.format(AssignCommand.MESSAGE_ALREADY_IN_PROJECT, targetMember.getName());
+        assertCommandFailure(assignCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidIndex_failure() {
+        Model model = new ModelManager(TypicalProjects.getTypicalSocket(), new UserPrefs());
+
+        // One based index, hence must add 2 to offset index 0 & reach out of bound.
+        int outOfBoundPerson = model.getFilteredPersonList().size() + 2;
+        int outOfBoundProject = model.getFilteredProjectList().size() + 2;
+
+        // AssignCommand to be tested.
+        AssignCommand personIndexWrongAssignCommand = new AssignCommand(
+                Index.fromOneBased(outOfBoundPerson), INDEX_FIRST_PROJECT);
+        AssignCommand projectIndexWrongAssignCommand = new AssignCommand(
+                INDEX_FIRST_PERSON, Index.fromOneBased(outOfBoundProject));
+        AssignCommand bothIndexWrongAssignCommand = new AssignCommand(
+                Index.fromOneBased(outOfBoundPerson), Index.fromOneBased(outOfBoundProject));
+
+        // Message expected when AssignCommand is executed.
+        String expectedPersonMessage = String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        String expectedProjectMessage = String.format(Messages.MESSAGE_INVALID_PROJECT_DISPLAYED_INDEX);
+
+        // Test cases.
+        assertCommandFailure(personIndexWrongAssignCommand, model, expectedPersonMessage);
+        assertCommandFailure(projectIndexWrongAssignCommand, model, expectedProjectMessage);
+        assertCommandFailure(bothIndexWrongAssignCommand, model, expectedPersonMessage);
+    }
+
+    @Test
+    public void testEquals() {
+        AssignCommand assignFirstCommand = new AssignCommand(INDEX_FIRST_PERSON, INDEX_FIRST_PROJECT);
+
+        // Same object -> returns true
+        assertTrue(assignFirstCommand.equals(assignFirstCommand));
+
+        // Same values -> returns true
+        AssignCommand assignFirstPersonCommandCopy = new AssignCommand(INDEX_FIRST_PERSON, INDEX_FIRST_PROJECT);
+        assertTrue(assignFirstCommand.equals(assignFirstPersonCommandCopy));
+
+        // Different types -> returns false
+        assertFalse(assignFirstCommand.equals(1));
+
+        // Null -> returns false
+        assertFalse(assignFirstCommand.equals(null));
+
+        // Different person Index -> returns false
+        AssignCommand assignSecondPersonCommand = new AssignCommand(INDEX_SECOND_PERSON, INDEX_FIRST_PROJECT);
+        assertFalse(assignFirstCommand.equals(assignSecondPersonCommand));
+
+        // Different project Index -> returns false
+        AssignCommand assignSecondProjectCommand = new AssignCommand(INDEX_FIRST_PERSON, INDEX_SECOND_PROJECT);
+        assertFalse(assignFirstCommand.equals(assignSecondProjectCommand));
+
+        // Different person & project Index -> returns false
+        AssignCommand assignSecondCommand = new AssignCommand(INDEX_SECOND_PERSON, INDEX_SECOND_PROJECT);
+        assertFalse(assignFirstCommand.equals(assignSecondCommand));
+    }
+}

--- a/src/test/java/seedu/socket/logic/parser/AssignCommandParserTest.java
+++ b/src/test/java/seedu/socket/logic/parser/AssignCommandParserTest.java
@@ -1,0 +1,59 @@
+package seedu.socket.logic.parser;
+
+import static seedu.socket.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.socket.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.socket.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.socket.testutil.TypicalIndexes.INDEX_FIRST_PROJECT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.socket.logic.commands.AssignCommand;
+
+public class AssignCommandParserTest {
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignCommand.MESSAGE_USAGE);
+    private AssignCommandParser parser = new AssignCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsAssignCommand() {
+        AssignCommand expectedAssignCommand = new AssignCommand(INDEX_FIRST_PERSON, INDEX_FIRST_PROJECT);
+        assertParseSuccess(parser, "1 1", expectedAssignCommand);
+        // Whitespace in front and behind
+        assertParseSuccess(parser, "  1 1  ", expectedAssignCommand);
+        // mMultiple whitespaces between keywords
+        assertParseSuccess(parser, "  \t \n 1   \t  \n 1 \t ", expectedAssignCommand);
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        // Empty String
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        // White space only
+        assertParseFailure(parser, " ", MESSAGE_INVALID_FORMAT);
+        // Multiple empty lines
+        assertParseFailure(parser, "\n", MESSAGE_INVALID_FORMAT);
+        // Tab only
+        assertParseFailure(parser, "\t", MESSAGE_INVALID_FORMAT);
+        // Tabs and Multiple empty lines
+        assertParseFailure(parser, "\n\n\t\t", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_incorrectNumberOfArgs_throwsParseException() {
+        // Only 1 Argument
+        assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
+        // More than 2 Arguments
+        assertParseFailure(parser, "1 1 1", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidIndex_throwsParseException() {
+        // Invalid person index only
+        assertParseFailure(parser, "a 1", MESSAGE_INVALID_FORMAT);
+        // Invalid project index only
+        assertParseFailure(parser, "1 a", MESSAGE_INVALID_FORMAT);
+        // Invalid person & project index
+        assertParseFailure(parser, "a a", MESSAGE_INVALID_FORMAT);
+    }
+}

--- a/src/test/java/seedu/socket/logic/parser/SocketParserTest.java
+++ b/src/test/java/seedu/socket/logic/parser/SocketParserTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.socket.logic.commands.AddCommand;
 import seedu.socket.logic.commands.AddProjectCommand;
+import seedu.socket.logic.commands.AssignCommand;
 import seedu.socket.logic.commands.ClearCommand;
 import seedu.socket.logic.commands.ClearProjectCommand;
 import seedu.socket.logic.commands.DeleteCommand;
@@ -304,6 +305,13 @@ public class SocketParserTest {
                 + INDEX_FIRST_PROJECT.getOneBased() + " " + REPO_NAME_DESC_ALPHA
                 + REPO_HOST_DESC_ALPHA + DEADLINE_DESC_ALPHA + MEETING_DESC_ALPHA);
         assertEquals(new RemoveProjectCommand(INDEX_FIRST_PROJECT, descriptor), command);
+    }
+
+    @Test
+    public void parseCommand_assign() throws Exception {
+        AssignCommand command = (AssignCommand) parser.parseCommand(AssignCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + INDEX_FIRST_PROJECT.getOneBased());
+        assertEquals(new AssignCommand(INDEX_FIRST_PERSON, INDEX_FIRST_PROJECT), command);
     }
 
     @Test


### PR DESCRIPTION
There is no way to assign a person to a project in SOCket through the program.

Let's
* Add a new command `assign` so that SOCket users can add a person from the currently displayed person list in SOCket to a project from the currently displayed person list in SOCket.

In addition to adding the new `AssignCommand.java` , `AssignCommandParser.java` and updating `SocketParser.java` for assign command, test cases for the assign command have been created and test cases for `SocketParser.java` has been updated to cover the new assign command.