### PR TITLE
Fix #242

### DIFF
--- a/src/main/java/seedu/socket/model/person/tag/Language.java
+++ b/src/main/java/seedu/socket/model/person/tag/Language.java
@@ -8,12 +8,13 @@ import static seedu.socket.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; name is valid as declared in {@link #isValidLanguageName(String)}
  */
 public class Language {
-    public static final String MESSAGE_CONSTRAINTS = "Language names should be a minimum of 1 character, start with a "
-            + "letter and consist of alphanumeric characters and/or -, +, #.";
+    public static final String MESSAGE_CONSTRAINTS = "Language names should be a minimum of 1 character and a maximum "
+            + "of 20 characters, start with a letter and consist of alphanumeric characters and/or -, +, #.";
     /**
-     * Should be a minimum of 1 character, start with a letter and consist of alphanumeric characters and/or -, +, #.
+     * Should be a minimum of 1 character and a maximum of 20 characters, start with a letter and consist of
+     * alphanumeric characters and/or -, +, #.
      */
-    public static final String VALIDATION_REGEX = "^(?=[a-zA-Z])[-+#a-zA-Z0-9]+";
+    public static final String VALIDATION_REGEX = "^(?=.{1,20}$)(?=[a-zA-Z])[-+#a-zA-Z0-9]+";
 
     public final String languageName;
 

--- a/src/test/java/seedu/socket/model/person/tag/LanguageTest.java
+++ b/src/test/java/seedu/socket/model/person/tag/LanguageTest.java
@@ -35,6 +35,7 @@ class LanguageTest {
         assertFalse(Language.isValidLanguageName("-")); // starts with valid special characters
         assertFalse(Language.isValidLanguageName("+")); // starts with valid special characters
         assertFalse(Language.isValidLanguageName("#")); // starts with valid special characters
+        assertFalse(Language.isValidLanguageName("C12345678901234567891")); // 21 characters
 
         // valid language name
         assertTrue(Language.isValidLanguageName("C")); // single alphabet only
@@ -44,6 +45,7 @@ class LanguageTest {
         assertTrue(Language.isValidLanguageName("C#")); // alphabets and valid special characters
         assertTrue(Language.isValidLanguageName("X10")); // alphanumeric characters
         assertTrue(Language.isValidLanguageName("abc-10")); // alphanumeric characters and valid special characters
+        assertTrue(Language.isValidLanguageName("C1234567890123456789")); // 20 characters
     }
 
     @Test


### PR DESCRIPTION
Language has no limit on length

Allows Language to extend indefinitely, causing a bug in the UI for viewing a Person where fields are meant to wrap when exceeding the card width

Update validation to only allow Language to be of maximum 20 characters

Update LanguageTest to cover bug fix