### PR TITLE
Fix error in AddProjectCommand usage message

### DIFF
--- a/src/main/java/seedu/socket/logic/commands/AddProjectCommand.java
+++ b/src/main/java/seedu/socket/logic/commands/AddProjectCommand.java
@@ -27,7 +27,7 @@ public class AddProjectCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Project 1 "
             + PREFIX_REPO_HOST + "project-1 "
-            + PREFIX_REPO_NAME + "ProjectOne"
+            + PREFIX_REPO_NAME + "ProjectOne "
             + PREFIX_DEADLINE + "29/04/22-0900 "
             + PREFIX_MEETING + "24/03/22-1400";
 


### PR DESCRIPTION
- Fix an error in the usage message for `addpj` command that provides an invalid example. 

- This fix also addresses #229 